### PR TITLE
Normalize post tags and align Microsoft 365 Copilot taxonomy

### DIFF
--- a/holgerimbery/_posts/2024-02-18-unlocking-productivity-and-creativity-harnessing-the-power-of-microsoft-365-copilot-with-good-prompts.md
+++ b/holgerimbery/_posts/2024-02-18-unlocking-productivity-and-creativity-harnessing-the-power-of-microsoft-365-copilot-with-good-prompts.md
@@ -5,7 +5,7 @@ description:
 date: 2024-02-18
 author: admin
 image: ./images/unlocking-productivity-and-creativity-harnessing-the-power-of-microsoft-365-copilot-with-good-prompts.jpeg
-tags: [prompts, copilot]
+tags: [prompts, copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-03-02-microsoft-365-graph-grounded-chat-prompts.md
+++ b/holgerimbery/_posts/2024-03-02-microsoft-365-graph-grounded-chat-prompts.md
@@ -5,7 +5,7 @@ description:
 date: 2024-03-02
 author: admin
 image: ./images/microsoft-365-graph-grounded-chat-prompts.jpeg
-tags: [copilot]
+tags: [copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-03-16-using-microsoft-copilot-in-word.md
+++ b/holgerimbery/_posts/2024-03-16-using-microsoft-copilot-in-word.md
@@ -5,7 +5,7 @@ description:
 date: 2024-03-16
 author: admin
 image: ./images/using-microsoft-copilot-in-word.jpeg
-tags: [copilot]
+tags: [copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-03-23-utilize-copilot-for-microsoft-365-to-enhance-the-effectiveness-of-your-email.md
+++ b/holgerimbery/_posts/2024-03-23-utilize-copilot-for-microsoft-365-to-enhance-the-effectiveness-of-your-email.md
@@ -5,7 +5,7 @@ description:
 date: 2024-03-23
 author: admin
 image: ./images/utilize-copilot-for-microsoft-365-to-enhance-the-effectiveness-of-your-email.jpeg
-tags: [copilot]
+tags: [copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-03-29-kickstart-your-experience-with-copilot-in-microsoft-teams-meetings.md
+++ b/holgerimbery/_posts/2024-03-29-kickstart-your-experience-with-copilot-in-microsoft-teams-meetings.md
@@ -5,7 +5,7 @@ description:
 date: 2024-03-29
 author: admin
 image: ./images/kickstart-your-experience-with-copilot-in-microsoft-teams-meetings.jpeg
-tags: [copilot]
+tags: [copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-04-06-improve-your-powerpoint-slides-with-creativity-tools-from-microsoft-365-copilot.md
+++ b/holgerimbery/_posts/2024-04-06-improve-your-powerpoint-slides-with-creativity-tools-from-microsoft-365-copilot.md
@@ -5,7 +5,7 @@ description:
 date: 2024-04-06
 author: admin
 image: ./images/improve-your-powerpoint-slides-with-creativity-tools-from-microsoft-365-copilot.jpeg
-tags: [copilot]
+tags: [copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-04-13-streamline-your-excel-work-effective-data-management-with-copilot.md
+++ b/holgerimbery/_posts/2024-04-13-streamline-your-excel-work-effective-data-management-with-copilot.md
@@ -5,7 +5,7 @@ description:
 date: 2024-04-13
 author: admin
 image: ./images/streamline-your-excel-work-effective-data-management-with-copilot.jpeg
-tags: [copilot]
+tags: [copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-04-20-enhancing-whiteboard-capabilities-with-copilot.md
+++ b/holgerimbery/_posts/2024-04-20-enhancing-whiteboard-capabilities-with-copilot.md
@@ -5,7 +5,7 @@ description:
 date: 2024-04-20
 author: admin
 image: ./images/enhancing-whiteboard-capabilities-with-copilot.jpeg
-tags: [copilot]
+tags: [copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-10-27-enhance-your-copilot-for-microsoft-365-experience-when-plain-copilot-isnt-enough.md
+++ b/holgerimbery/_posts/2024-10-27-enhance-your-copilot-for-microsoft-365-experience-when-plain-copilot-isnt-enough.md
@@ -5,7 +5,7 @@ description:
 date: 2024-10-27
 author: admin
 image: ./images/enhance-your-copilot-for-microsoft-365-experience-when-plain-copilot-isnt-enough.jpeg
-tags: [copilot, copilotstudio, declarativeagents, teamstoolkit]
+tags: [copilot, microsoft365copilot, copilotstudio, declarativeagents, teamstoolkit]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2024-11-03-revolutionizing-teamwork-unleashing-the-power-of-copilot-pages-for-seamless-document-collaboration-with-links-for-it-admins.md
+++ b/holgerimbery/_posts/2024-11-03-revolutionizing-teamwork-unleashing-the-power-of-copilot-pages-for-seamless-document-collaboration-with-links-for-it-admins.md
@@ -5,7 +5,7 @@ description:
 date: 2024-11-03
 author: admin
 image: ./images/revolutionizing-teamwork-unleashing-the-power-of-copilot-pages-for-seamless-document-collaboration-with-links-for-it-admins.jpeg
-tags: [copilot]
+tags: [copilot, microsoft365copilot]
 featured: false
 toc: true
 

--- a/holgerimbery/_posts/2025-01-19-Comparison-of-Copilot-Chat-and-Copilot-for-Microsoft365.md
+++ b/holgerimbery/_posts/2025-01-19-Comparison-of-Copilot-Chat-and-Copilot-for-Microsoft365.md
@@ -5,7 +5,7 @@ date: 2025-01-19 10:28
 author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/01/jason-goodman-nF0nQuqBsrI-unsplash.jpg
 image_caption: 'Photo by <a href="https://unsplash.com/@jasongoodman_youxventures?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Jason Goodman</a> on <a href="https://unsplash.com/photos/two-women-sitting-in-front-of-white-table-nF0nQuqBsrI?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>'
-tags: [copilot, copilotstudio]
+tags: [copilot, microsoft365copilot, copilotstudio]
 summary: 
 featured: false
 toc: true

--- a/holgerimbery/_posts/2025-01-26-m365-copilot-extensibility-servicenow.md
+++ b/holgerimbery/_posts/2025-01-26-m365-copilot-extensibility-servicenow.md
@@ -6,7 +6,7 @@ date: 2025-01-26 10:28
 author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/01/linkedin-sales-solutions-46bom4lObsA-unsplash.jpg
 image_caption: 'Photo by <a href="https://unsplash.com/@linkedinsalesnavigator?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">LinkedIn Sales Solutions</a> on <a href="https://unsplash.com/photos/two-women-sitting-at-a-table-looking-at-a-computer-screen-46bom4lObsA?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>'     
-tags: [copilotstudio, copilot, servicenow, copilot extensibility]
+tags: [copilotstudio, copilot, servicenow, copilot-extensibility]
 summary:
 featured: false
 toc: true

--- a/holgerimbery/_posts/2025-02-11-Transform-Your-Sales-Operations-Integrate-Salesforce-with-Copilot-for-Microsoft-365.md
+++ b/holgerimbery/_posts/2025-02-11-Transform-Your-Sales-Operations-Integrate-Salesforce-with-Copilot-for-Microsoft-365.md
@@ -6,7 +6,7 @@ date: 2025-02-11
 author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/02/linkedin-sales-solutions-YDVdprpgHv4-unsplash.jpg
 image_caption: 'Photo by <a href="https://unsplash.com/@linkedinsalesnavigator?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">LinkedIn Sales Solutions</a> on <a href="https://unsplash.com/photos/unknown-person-using-laptop-YDVdprpgHv4?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>'    
-tags: [copilotstudio, copilot, salesforce, copilot extensibility]
+tags: [copilotstudio, copilot, microsoft365copilot, salesforce, copilot-extensibility]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2025-06-14-autonomous-agents-the future-of automation.md
+++ b/holgerimbery/_posts/2025-06-14-autonomous-agents-the future-of automation.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/06/daulet-turubayev-RAwn1QFwfss-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@dauletrb?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Daulet Turubayev</a> on <a href="https://unsplash.com/photos/two-men-working-on-a-machine-in-a-factory-RAwn1QFwfss?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>
       
-tags: [copilotstudio, autonomousagents, agents, automation]   
+tags: [copilotstudio, autonomousagents, agents, automation]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2025-08-31-copilot-studio-kit-webchat-playground.md
+++ b/holgerimbery/_posts/2025-08-31-copilot-studio-kit-webchat-playground.md
@@ -6,7 +6,7 @@ description: The Webchat Playground in the Copilot Studio Kit is a practical uti
 date: 2025-08-31
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/08/dave-sherrill-HjEKj1yMAdQ-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@daveatjude3?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Dave Sherrill</a> on <a href="https://unsplash.com/photos/white-and-brown-wooden-bench-near-body-of-water-during-daytime-HjEKj1yMAdQ?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>
-tags: [copilotstudio, webchat, copilotstudiokit]
+tags: [copilotstudio, webchat, copilotstudio-kit]
 author: admin
 featured: false
 toc: true

--- a/holgerimbery/_posts/2025-12-06-multi-agent-orchestration.md
+++ b/holgerimbery/_posts/2025-12-06-multi-agent-orchestration.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/12/hannah-busing-Zyx1bK9mqmA-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@hannahbusing?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Hannah Busing</a> on <a href="https://unsplash.com/photos/person-in-red-sweater-holding-babys-hand-Zyx1bK9mqmA?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
-tags: [copilotstudio, agents, multiagent, modelcontectprotocol, aifoundry]
+tags: [copilotstudio, agents, multiagent, modelcontextprotocol, aifoundry]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2025-12-27-VisualStudioCode-AI-Toolkit.md
+++ b/holgerimbery/_posts/2025-12-27-VisualStudioCode-AI-Toolkit.md
@@ -6,7 +6,7 @@ date: 2025-12-27 06:38:53 +0100
 author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/12/barn-images-t5YUoHW6zRo-unsplash.jpg
 image_caption: Visual Studio Code AI Toolkit
-tag: [agents, development, vscode, aitoolkit, aifoundry]
+tags: [agents, development, vscode, aitoolkit, aifoundry]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-01-24-migrating-from-agent-builder-to-copilot-studio.md
+++ b/holgerimbery/_posts/2026-01-24-migrating-from-agent-builder-to-copilot-studio.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2026/01/yoel-winkler-iPPukR_eMcY-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@yoel100?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Yoel Winkler</a> on <a href="https://unsplash.com/photos/a-flock-of-birds-flying-through-a-blue-sky-iPPukR_eMcY?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
-tags: [copilot, copilotstudio, agentbuilder, migration, powerplatform, agents,enterpriseagents]
+tags: [copilot, copilotstudio, agentbuilder, migration, powerplatform, agents, enterpriseagents]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-01-31-ship-copilot-studio-agents-with-confidence-master-automated-testing-with-the-copilot-studio-kit.md
+++ b/holgerimbery/_posts/2026-01-31-ship-copilot-studio-agents-with-confidence-master-automated-testing-with-the-copilot-studio-kit.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2026/01/testalize-me-0jE8ynV4mis-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@testalizeme?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Testalize.me</a> on <a href="https://unsplash.com/photos/green-pink-and-purple-plastic-bottles-0jE8ynV4mis?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
-tags: [copilotstudio, powerplatform, agentevaluation, ai, llm, testing, governance, devops, copilotstudiokit]
+tags: [copilotstudio, powerplatform, agentevaluation, ai, llm, testing, governance, devops, copilotstudio-kit]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-03-14-microsoft-365-e7-why-microsoft-s-new-license-is-a-logical-step-for-agent-driven-enterprises.md
+++ b/holgerimbery/_posts/2026-03-14-microsoft-365-e7-why-microsoft-s-new-license-is-a-logical-step-for-agent-driven-enterprises.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2026/03/luke-heibert-gthSas4oYC0-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@lukeheibert?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Luke Heibert</a> on <a href="https://unsplash.com/photos/a-lot-of-brown-boxes-that-are-open-gthSas4oYC0?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
-tags: [Microsoft 365, E7, Enterprise Licensing, agents, Agent365, Copilot]
+tags: [microsoft365, microsoft365copilot, e7, enterprise-licensing, agents, agent365, copilot]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-03-21-practical-guideline-how-to-move-agents-beyond-pocs-and-deliver-real-enterprise-value.md
+++ b/holgerimbery/_posts/2026-03-21-practical-guideline-how-to-move-agents-beyond-pocs-and-deliver-real-enterprise-value.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2026/03/thao-lee-yYSY93clr4w-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@h4x0r3?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Thao LEE</a> on <a href="https://unsplash.com/photos/group-of-martial-artists-sitting-on-the-grounds-yYSY93clr4w?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
-tags: [CopilotStudio, Agents, AIFoundry, AIAdoption, EnterpriseAI, FrontierFirm, Implementation, Governance, Value]
+tags: [copilotstudio, agents, aifoundry, aiadoption, enterpriseai, frontierfirm, implementation, governance, value]
 featured: false
 toc: true
 ---
@@ -123,4 +123,3 @@ Throughout the development cycle, **applying production-grade governance control
 Supporting this development rhythm requires establishing **lightweight review processes calibrated to the urgency of decisions**, and separating continuous operational assessments from episodic capability expansion decisions. Organizations must enforce **time-bound value realization through a commitment to deliver measurable operational results within thirty days**, which prevents indefinite deferral of production deployment and forces disciplined conversations about scope alignment. As operational requirements expand, maintaining **modular architectures that distribute capabilities across multiple specialized agents** rather than accumulating responsibilities within single agents preserves development velocity and simplifies operational governance. Finally, **planning for long-term flexibility through well-defined interfaces and standardized protocols** enables the agent ecosystem to adapt as organizational technology infrastructure and business requirements evolve.
 
 These principles work together to create implementation patterns that compress the transition from conception to the delivery of operational value.
-

--- a/holgerimbery/_posts/2026-04-04-azure-local-foundry-local-and-microsoft-365-local-a-comprehensive-guide-for-it-architects-and-decision-makers.md
+++ b/holgerimbery/_posts/2026-04-04-azure-local-foundry-local-and-microsoft-365-local-a-comprehensive-guide-for-it-architects-and-decision-makers.md
@@ -8,7 +8,7 @@ image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/hol
 image_caption: Photo by <a href="https://unsplash.com/@kevinache?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Kevin Ache</a> on <a href="https://unsplash.com/photos/a-rack-of-servers-in-a-server-room-2JJ3wBHu4_0?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
       
-tags: [Azurelocal, foundrylocal, m365 local, Agents, FrontierFirm, Implementation, SovereignPrivateCloud]
+tags: [azurelocal, foundrylocal, m365-local, agents, frontierfirm, implementation, sovereignprivatecloud]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-04-11-building-on-prem-ai-agents-with-azure-local-foundry-local-and-microsoft-agent-framework.md
+++ b/holgerimbery/_posts/2026-04-11-building-on-prem-ai-agents-with-azure-local-foundry-local-and-microsoft-agent-framework.md
@@ -8,7 +8,7 @@ image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/hol
 image_caption: Photo by <a href="https://unsplash.com/@tvick?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Taylor Vick</a> on <a href="https://unsplash.com/photos/cable-network-M5tzZtFCOfs?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
             
-tags: [azurelocal, foundrylocal, Agents, FrontierFirm, Implementation, SovereignPrivateCloud, OnPremAI, LocalInference, MicrosoftAgentFramework]
+tags: [azurelocal, foundrylocal, agents, frontierfirm, implementation, sovereignprivatecloud, onpremai, localinference, microsoftagentframework]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-04-25-iqs.md
+++ b/holgerimbery/_posts/2026-04-25-iqs.md
@@ -8,7 +8,7 @@ image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/hol
 image_caption: Photo by <a href="https://unsplash.com/@silverkblack?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Vitaly Gariev</a> on <a href="https://unsplash.com/photos/fashion-designer-working-on-a-laptop-in-her-studio-KolBZlJbiro?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
                   
-tags: [WorkIQ, FabricIQ, FoundryIQ, copilotstudio, agents]
+tags: [workiq, fabriciq, foundryiq, copilotstudio, agents]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-05-09-agent-365-ga.md
+++ b/holgerimbery/_posts/2026-05-09-agent-365-ga.md
@@ -8,7 +8,7 @@ image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/hol
 image_caption: Photo by <a href="https://unsplash.com/@jeshoots?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">JESHOOTS.COM</a> on <a href="https://unsplash.com/photos/depth-of-field-photography-of-man-playing-chess-fzOITuS1DIQ?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
 
-tags: [Agent365, Copilot, Entra, Purview, Defender, agents]
+tags: [agent365, copilot, entra, purview, defender, agents]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-05-30-powerplatform-licensing.md
+++ b/holgerimbery/_posts/2026-05-30-powerplatform-licensing.md
@@ -9,7 +9,7 @@ image_caption: Photo by <a href="https://unsplash.com/@andretaissin?utm_source=u
       
 
 
-tags: ["powerplatform", "licensing", "copilotstudio", "dataverse", "dynamics365contactcenter", "dynamics365customerservice"]
+tags: [powerplatform, licensing, copilotstudio, dataverse, dynamics365contactcenter, dynamics365customerservice]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-06-27-teams-phone-agent-copilot-studio.md
+++ b/holgerimbery/_posts/2026-06-27-teams-phone-agent-copilot-studio.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2026/06/annie-spratt-goholCAVTRs-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@anniespratt?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Annie Spratt</a> on <a href="https://unsplash.com/photos/brown-rotary-dial-telephone-in-gray-painted-room-goholCAVTRs?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
 
-tags: ["microsoftteams", "teamsphone", "copilotstudio", "voiceagents", "autoattendant", "callqueue", "frontier"]
+tags: [microsoftteams, teamsphone, copilotstudio, voiceagents, autoattendant, callqueue, frontier]
 featured: false
 toc: false
 ---


### PR DESCRIPTION
This updates post frontmatter tagging to make the taxonomy consistent and easier to filter reliably across the site.

## Why
Tag usage had drifted across case/style variants (for example `tag` vs `tags`, mixed-case labels, and near-duplicate spellings), and Microsoft 365 Copilot content was split between broad `copilot` tagging and the more specific `microsoft365copilot` tag.

## What changed
- Normalized frontmatter tags in `_posts` to consistent lowercase canonical values.
- Converted the remaining `tag:` key to `tags:`.
- Merged known variant spellings into canonical tags (for example `copilotstudiokit` -> `copilotstudio-kit`, `modelcontectprotocol` -> `modelcontextprotocol`).
- Added `microsoft365copilot` to clearly Microsoft 365 Copilot-focused posts while keeping `copilot` as the broader umbrella tag.

## Result
- 27 post files updated.
- 0 remaining `tag:` keys.
- Removed mixed-case and duplicate-variant tag collisions.
- Improved separation and overlap between `copilot` and `microsoft365copilot` for clearer discovery and filtering.