### PR TITLE
Refine remaining tag synonym mappings

### DIFF
--- a/holgerimbery/_posts/2025-04-26-pay-as-you-go-payment-copilot-agents-agentflows.md
+++ b/holgerimbery/_posts/2025-04-26-pay-as-you-go-payment-copilot-agents-agentflows.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/04/blake-wisz-q3o_8MteFM0-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@blakewisz?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Blake Wisz</a> on <a href="https://unsplash.com/photos/woman-holding-magnetic-card-q3o_8MteFM0?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>
       
-tags: [copilotstudio, pay-as-you-go, agentflow, azure, subscription]
+tags: [copilotstudio, pay-as-you-go, agentflows, azure, subscription]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2025-09-06-copilot-studio-agentbuilder-vs-copilot-studio.md
+++ b/holgerimbery/_posts/2025-09-06-copilot-studio-agentbuilder-vs-copilot-studio.md
@@ -6,7 +6,7 @@ description: A technical comparison of Copilot Studio Agent Builder and Microsof
 date: 2025-09-06
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2025/09/danist-soh-8Gg2Ne_uTcM-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@danist07?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Danist Soh</a> on <a href="https://unsplash.com/photos/low-angle-photography-of-cranes-on-top-of-building-8Gg2Ne_uTcM?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>
-tags: [copilotstudio, copilotstudioagentbuilder, agents]
+tags: [copilotstudio, agentbuilder, agents]
 author: admin
 featured: false
 toc: true

--- a/holgerimbery/_posts/2026-02-07-microsoft-frontier-agents-a-deep-technical-overview.md
+++ b/holgerimbery/_posts/2026-02-07-microsoft-frontier-agents-a-deep-technical-overview.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2026/02/dan-meyers-aGLFozyvXsQ-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@dmey503?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Dan Meyers</a> on <a href="https://unsplash.com/photos/body-of-water-near-mountain-during-sunset-aGLFozyvXsQ?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
-tags: [copilotstudio, frontier, microsoft365, agents, enterpriseai, agent365, m365copilot]
+tags: [copilotstudio, frontier, agents, enterpriseai, agent365, microsoft365copilot]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-03-14-microsoft-365-e7-why-microsoft-s-new-license-is-a-logical-step-for-agent-driven-enterprises.md
+++ b/holgerimbery/_posts/2026-03-14-microsoft-365-e7-why-microsoft-s-new-license-is-a-logical-step-for-agent-driven-enterprises.md
@@ -7,7 +7,7 @@ author: admin
 image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/2026/03/luke-heibert-gthSas4oYC0-unsplash.jpg
 image_caption: Photo by <a href="https://unsplash.com/@lukeheibert?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Luke Heibert</a> on <a href="https://unsplash.com/photos/a-lot-of-brown-boxes-that-are-open-gthSas4oYC0?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
       
-tags: [microsoft365, microsoft365copilot, e7, enterprise-licensing, agents, agent365, copilot]
+tags: [microsoft365copilot, e7, enterprise-licensing, agents, agent365, copilot]
 featured: false
 toc: true
 ---

--- a/holgerimbery/_posts/2026-05-23-powerplatform-governance-part-2.md
+++ b/holgerimbery/_posts/2026-05-23-powerplatform-governance-part-2.md
@@ -8,7 +8,7 @@ image: https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/hol
 image_caption: Photo by <a href="https://unsplash.com/@charles_forerunner?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Charles Forerunner</a> on <a href="https://unsplash.com/photos/people-standing-inside-city-building-3fPXt37X6UQ?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
 
 
-tags: [copilotstudio, agents, governance, powerplatform, dataverse, security, compliance, alm, pipelines]
+tags: [copilotstudio, agents, governance, powerplatform, dataverse, security, compliance, applicationlifecyclemanagement, pipelines]
 featured: false
 toc: true
 ---


### PR DESCRIPTION
This cleans up a few remaining tag synonyms so filtering and archive discovery stay consistent across posts.

## Why
After the broader normalization pass, a small set of semantically overlapping tags still existed (`alm`, `agentflow`, `m365copilot`, and `copilotstudioagentbuilder`). These fragments split related content into separate buckets.

## What changed
- `alm` -> `applicationlifecyclemanagement`
- `agentflow` -> `agentflows`
- `m365copilot` -> `microsoft365copilot`
- `copilotstudioagentbuilder` -> `agentbuilder`
- Removed `microsoft365` where it duplicated the more specific `microsoft365copilot` tagging

## Scope
- 5 post frontmatter files updated
- Tag values only; no post body/content changes