### PR TITLE
Rewrite inline post image links to raw GitHub URLs

### DIFF
--- a/holgerimbery/_posts/2022-11-19-build-your-first-voice-bot-with-microsoft-power-virtual-agent-3e71f8531c3a.md
+++ b/holgerimbery/_posts/2022-11-19-build-your-first-voice-bot-with-microsoft-power-virtual-agent-3e71f8531c3a.md
@@ -48,7 +48,7 @@ Use [GitHub for Application Lifecycle Management](https://learn.microsoft.com/en
 
 Launch Power Virtual Agents editing [canvas](https://web.powerva.microsoft.com) and create your first chatbot.
 
-![Figure 2: Create your first chatbot]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/vg0pswspc.png)
+![Figure 2: Create your first chatbot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/vg0pswspc.png)
 
 Figure 2: Create your first chatbot
 
@@ -58,13 +58,13 @@ Microsoft installed some default topics and entities; as we want to begin from n
 
 Delete "Lession 3"
 
-![Figure 3: Delete "Lesson 3"]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/xtl21mndz.png)
+![Figure 3: Delete "Lesson 3"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/xtl21mndz.png)
 
 Figure 3: Delete "Lesson 3"
 
 Next, we go to the "Greetings" Topic and change the flow by modifying the first message.
 
-![Figure 4: Modify greeting]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/v5hhwdomo.png)
+![Figure 4: Modify greeting](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/v5hhwdomo.png)
 
 Figure 4: Modify greeting
 
@@ -72,7 +72,7 @@ Keep in mind would like to use the bot on the phone - this means no graphics
 
 Next, we need to create a new "Confirmed Success" topic named "Success".
 
-![Figure 5: Create a new Question node and name the response as "answer"]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/ufwuphdqj.png)
+![Figure 5: Create a new Question node and name the response as "answer"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/ufwuphdqj.png)
 
 Figure 5: Create a new Question node and name the response as "answer"*
 
@@ -92,17 +92,17 @@ No
 No, thanks
 ```
 
-![Figure 6: Create two negative conditions]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/svsj5yssu.png)
+![Figure 6: Create two negative conditions](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/svsj5yssu.png)
 
 Figure 6: Create two negative conditions*
 
-![Figure 7:  as-well-as two positive conditions]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/lz7b6udra.png)
+![Figure 7:  as-well-as two positive conditions](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/lz7b6udra.png)
 
 Figure 7: as-well-as two positive conditions*
 
 This newly created topic will replace the last node, "Confirmed Success" in the "End of Conversation" topic. As "Confirmed Success" is not suitable for voice bots as there is a graphical feedback element involved.
 
-![Figure 8: Replace the last node]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/wfgfn1pmj.png)
+![Figure 8: Replace the last node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/wfgfn1pmj.png)
 
 Figure 8: Replace the last node
 
@@ -114,7 +114,7 @@ Voice AI Connect is available in two flavors:
 
 * An enterprise solution, you can host yourself on Azure and bring your Carrier or as a fully managed solution with phone numbers. You can ask me to get the insides.
 
-![Figure 9: Create a "Message" and a "transfer to agent" node]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/puygx6vgg.png)
+![Figure 9: Create a "Message" and a "transfer to agent" node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/puygx6vgg.png)
 
 Figure 9: Create a "Message" and a "transfer to agent" node
 
@@ -130,7 +130,7 @@ Please hold the line; you will be connected to a human.
 
 Finally, modify the "Escalation" topic to use the newly created "tranfer_agent_pva" topic as the end node.
 
-![Figure 10: Remove message node and add "transfer_agent_pva" as end node]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/km0wq8kdg.png)
+![Figure 10: Remove message node and add "transfer_agent_pva" as end node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/km0wq8kdg.png)
 
 Figure 10: Remove message node and add "transfer_agent_pva" as end node
 
@@ -146,7 +146,7 @@ Let´s assume we want to answer questions, on the phone, regarding our opening h
 
 We open "Lesson 1" and rename it to "Opening hours"
 
-![Figure 11: modify both message nodes]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/segzhallv.png)
+![Figure 11: modify both message nodes](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/segzhallv.png)
 
 Figure 11: modify both message nodes
 
@@ -166,7 +166,7 @@ The Frankfurt hours are: Mon-Fri:
 
 Let´s assume we want to answer, on the phone, questions regarding our store location.
 
-![Figure 12: Modify nodes]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/vszwm0mav.png)
+![Figure 12: Modify nodes](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/vszwm0mav.png)
 
 Figure 12: Modify nodes
 
@@ -198,7 +198,7 @@ By integrating a custom entry, we make the dialog more natural. The caller can a
 
 #### Create Custom Entity
 
-![Figure 13: Create a Custom Entity "IVRTargets" as closed lis]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/h3eg35lxx.png)
+![Figure 13: Create a Custom Entity "IVRTargets" as closed lis](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/h3eg35lxx.png)
 
 Figure 13: Create a Custom Entity "IVRTargets" as closed list
 
@@ -262,7 +262,7 @@ help
 
 Rename "Lesson 4" to "IVRReplacement"
 
-![Figure 14: Change trigger phrases]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/s2qaz6mgx.png)
+![Figure 14: Change trigger phrases](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/s2qaz6mgx.png)
 
 Figure 14: Change trigger phrases
 
@@ -280,27 +280,27 @@ I want to talk to Support
 
 We use the created custom entity "IVRTargets" as a switchboard; if there is no identifiable target, we route to the standard human escalation point "Escalate" with the redirect to "transfer_agent_pva".
 
-![Figure 15: Change the question node, use custom entity "IVRTargets"]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/zhvko7xn6.png)
+![Figure 15: Change the question node, use custom entity "IVRTargets"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/zhvko7xn6.png)
 
 Figure 15: Change the question node, use custom entity "IVRTargets"
 
-![Figure 16: Change condition for human resources]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/22ddagvyr.png)
+![Figure 16: Change condition for human resources](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/22ddagvyr.png)
 
 Figure 16: Change condition for human resources
 
-![Figure 17: Change condition for sales]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/9thrub3c0.png)
+![Figure 17: Change condition for sales](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/9thrub3c0.png)
 
 Figure 17: Change condition for sales
 
-![Figure 18: Change condition for support]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/otlqhdspd.png)
+![Figure 18: Change condition for support](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/otlqhdspd.png)
 
 Figure 18: Change condition for support
 
-![Figure 19: Change condition for others]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/dunsvnurwp.png)
+![Figure 19: Change condition for others](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/dunsvnurwp.png)
 
 Figure 19: Change condition for others
 
-![Figure 20: Add a phone number to each target as a private message to agent]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/ik9lajqwi.png)
+![Figure 20: Add a phone number to each target as a private message to agent](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/ik9lajqwi.png)
 
 Figure 20: Add a phone number to each target as a private message to agent
 
@@ -318,19 +318,19 @@ With an adaptive Card, e.g., to a Microsoft Teams Channel, you could give your h
 
 Add questions to the "IVRReplacement" topic, e.g., asking for the transfer reason and a customer number.
 
-![Figure 21: Add questions]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/m4dfhkxad.png)
+![Figure 21: Add questions](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/m4dfhkxad.png)
 
 Figure 21: Add questions
 
 The user's response will be stored into a variable each, which we use as input for our power automate flow.
 
-![Figure 22: additional flow]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/vr7iamhzo.png)
+![Figure 22: additional flow](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/vr7iamhzo.png)
 
 Figure 22: additional flow
 
 The flow itself is straightforward.
 
-![Figure 23: Add "Post adaptive card in a chat or channel" action]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/3zane-8bd.png)
+![Figure 23: Add "Post adaptive card in a chat or channel" action](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/3zane-8bd.png)
 
 Figure 23: Add "Post adaptive card in a chat or channel" action
 
@@ -375,7 +375,7 @@ an example adaptive card could look like this, you need to edit the parts in "&l
 The resulting message will look like the picture below.  
 Please remember not to execute flows in a productive environment with a user's account; always use service principal accounts.
 
-![Figure 24: example message]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/z5hq7hrwv.png)
+![Figure 24: example message](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/z5hq7hrwv.png)
 
 Figure 24: example message
 
@@ -393,13 +393,13 @@ To use the component, you need to extract the bot id from the power virtual agen
 you can find the ID within the Settings/Channels/Custom Website  
 (the red part between "/bots/new_bot_" and "/webchat" )
 
-![Figure 25: Retrieve the bot ID]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/4c2jfsjd7.png)
+![Figure 25: Retrieve the bot ID](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/4c2jfsjd7.png)
 
 Figure 25: Retrieve the bot ID
 
 You can find a working example on [GitHub](https://github.com/the-cognitiveservices-ninja/webchat-pva). The example is prepopulated with configuration options; please see details on the configuration options within the [defaultStyleOptions.ts](https://github.com/microsoft/BotFramework-WebChat/blob/master/packages/api/src/defaultStyleOptions.ts) file within the repository of Microsoft´s webchat component.
 
-![Figure 26: example website]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/cucn-mdki.png)
+![Figure 26: example website](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/cucn-mdki.png)
 
 Figure 26: example website
 
@@ -409,7 +409,7 @@ Please sign up for "[Voice.Ai Connect Cloud](https://voiceaiconnect.audiocodes.i
 
 Let´s give the bot a voice. Retrieve your Web channel Secret (in PVA: Settings/Security/Web Channel Security)
 
-![Figure 27: retrieve your Web channel Secret]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/bhtwggirw.png)
+![Figure 27: retrieve your Web channel Secret](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/bhtwggirw.png)
 
 Figure 27: retrieve your Web channel Secret
 
@@ -419,21 +419,21 @@ and go to your Voice.AI Configuration Interface.
 
 Add the Bot
 
-![Figure 28: Add details for your bot.]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/wya1-hai1.png)
+![Figure 28: Add details for your bot.](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/wya1-hai1.png)
 
 Figure 28: Add details for your bot.
 
-![Figure 29: Select TTS, STT and Voice Font]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/z742cfy5a.png)
+![Figure 29: Select TTS, STT and Voice Font](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/z742cfy5a.png)
 
 Figure 29: Select TTS, STT and Voice Font
 
 #### Configure Routing
 
-![Figure 30: configure routing "inbound"]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/3hel6mpog.png)
+![Figure 30: configure routing "inbound"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/3hel6mpog.png)
 
 Figure 30: configure routing "inbound"
 
-![Figure 31: configure routing "transfer"]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/sj6j0fzjx.png)
+![Figure 31: configure routing "transfer"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/sj6j0fzjx.png)
 
 Figure 31: configure routing "transfer"
 
@@ -447,13 +447,13 @@ With Power Virtual Agents, the use cases are limitless and based on the requirem
 
 Create a new topic "Feedback"
 
-![Figure 32: create trigger phrases]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/wjarfi21m.png)
+![Figure 32: create trigger phrases](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/wjarfi21m.png)
 
 Figure 32: create trigger phrases
 
 and add 2 Nodes,
 
-![Figure 33: one message node to greet the User and a Question node to get Feedback]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/uwsbcxhas.png)
+![Figure 33: one message node to greet the User and a Question node to get Feedback](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/uwsbcxhas.png)
 
 Figure 33: one message node to greet the User and a Question node to get Feedback*
 
@@ -463,31 +463,31 @@ Welcome to our Feedback System.
 How was your experience with this virtual assistant?
 ```
 
-![Figure 34: Create a new Power Automate Flow with input and output and later a message to display the output]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/vnctpk31i.png)
+![Figure 34: Create a new Power Automate Flow with input and output and later a message to display the output](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/vnctpk31i.png)
 
 Figure 34: Create a new Power Automate Flow with input and output and later a message to display the output
 
-![Figure 35: initialize a variable and analyse the sentiment]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/gq4qvoixa.png)
+![Figure 35: initialize a variable and analyse the sentiment](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/gq4qvoixa.png)
 
 Figure 35: initialize a variable and analyse the sentiment
 
-![Figure 36: initialize a variable, set it to "overall text sentiment" and a switch]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/6aqlka8ik.png)
+![Figure 36: initialize a variable, set it to "overall text sentiment" and a switch](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/6aqlka8ik.png)
 
 Figure 36: initialize a variable, set it to "overall text sentiment" and a switch
 
-![Figure 37: create a positive case with Response to User]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/yuh7xktug.png)
+![Figure 37: create a positive case with Response to User](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/yuh7xktug.png)
 
 Figure 37: create a positive case with Response to User
 
-![Figure 38: create a negative case with Response to User]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/sxzhy3bqc.png)
+![Figure 38: create a negative case with Response to User](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/sxzhy3bqc.png)
 
 Figure 38: create a negative case with Response to User
 
-![Figure 39: create a neutral/default case with Response to User]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/bljr4rdrh.png)
+![Figure 39: create a neutral/default case with Response to User](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/bljr4rdrh.png)
 
 Figure 39: create a neutral/default case with Response to User
 
-![Figure 40: return the Response to PVA]({{site.baseurl}}/images/clanwregx000008l96xpb5ugz.md/lvts4etar.png)
+![Figure 40: return the Response to PVA](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clanwregx000008l96xpb5ugz.md/lvts4etar.png)
 
 Figure 40: return the Response to PVA
 

--- a/holgerimbery/_posts/2022-11-26-power-virtual-agents-application-lifecycle-management-38bf9882e2d6.md
+++ b/holgerimbery/_posts/2022-11-26-power-virtual-agents-application-lifecycle-management-38bf9882e2d6.md
@@ -33,17 +33,17 @@ A GitHub repository to store your solution and all your workflow files.
 
 Please consider a governance solution like "[Landing Zones for Power Platform](https://cloudblogs.microsoft.com/powerplatform/2022/02/18/north-star-architecture-and-landing-zones-for-power-platform/#:~:text=Within%20the%20context%20of%20the%20North%20Star%20Architecture%2C,regardless%20of%20citizen%20developer%20or%20professional%20developer%20persona.)" to create and manage your environments (Role-based Access Control [RBAC], apply policies, including data loss prevention, allowing connectors, or denying some), primarily if you work with fusion teams of pro and low-code developers. "Landing Zones for Power Platform" is Microsoft Reference architecture to govern Power Platform Deployments.
 
-![Figure 2: deployment of your landing zones]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/tubuzupcw.png)
+![Figure 2: deployment of your landing zones](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/tubuzupcw.png)
 
 Figure 2: deployment of your landing zones
 
-![Figure 3: assign policies to your landing zones]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/xh2ci3sup.png)
+![Figure 3: assign policies to your landing zones](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/xh2ci3sup.png)
 
 Figure 3: assign policies to your landing zones
 
 ### The idea behind the workflows
 
-![Figure 4: GitHub Actions Workflow]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/rfee74e0h.png)
+![Figure 4: GitHub Actions Workflow](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/rfee74e0h.png)
 
 Figure 4: GitHub Actions Workflow
 
@@ -57,7 +57,7 @@ After end-to-end testing, we create a new release on GitHub, and
 
 #### Create a service principal account
 
-![Figure 5: Create a new App registrations on Azure]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/s5ob26nmb.png)
+![Figure 5: Create a new App registrations on Azure](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/s5ob26nmb.png)
 
 Figure 5: Create new App registrations on Azure
 
@@ -93,7 +93,7 @@ Next, proceed to create a client secret. In the navigation panel, select "Certif
 
 #### Create an application user
 
-![Figure 6: Create a new application user]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/f461zbnui.png)
+![Figure 6: Create a new application user](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/f461zbnui.png)
 
 Figure 6: Create a new application user
 
@@ -115,7 +115,7 @@ With the "App registration" and the "Application User", we can use "GitHub Actio
 
 #### Create a Solution
 
-![Figure 7: Create a new solution in Power Platform Admin Center]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/pwpvir7lm.png)
+![Figure 7: Create a new solution in Power Platform Admin Center](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/pwpvir7lm.png)
 
 Figure 7: Create a new solution in Power Platform Admin Center
 
@@ -137,13 +137,13 @@ Within the solution, you will find all your bots, flows, connector references, a
 
 * After adding your bot use the tree dots menu item and "+ add required objects" to get everything into the solution.
 
-![Figure 8: Add everything to the solution]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/grgey7a1e.png)
+![Figure 8: Add everything to the solution](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/grgey7a1e.png)
 
 Figure 8: add everything to the solution
 
 #### Create a new GitHub secret for Service Principal Authentication
 
-![Figure 9: Create a new GitHub Secret]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/7ko-2iafc.png)
+![Figure 9: Create a new GitHub Secret](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/7ko-2iafc.png)
 
 Figure 9: Create a new GitHub Secret
 
@@ -247,7 +247,7 @@ jobs:
 
 to start this manual flow, go to "Action", select the flow, click "Run workflow" and insert your values into the fields.
 
-![Figure 10: export to a new branch dialog]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/xzqout-i9.gif)
+![Figure 10: export to a new branch dialog](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/xzqout-i9.gif)
 
 Figure 10: export to a new branch dialog
 
@@ -526,7 +526,7 @@ jobs:
 
 to start this manual flow, go to "Action", select the flow, click "Run workflow" and insert your values into the fields.
 
-![Figure 11: Dialog to deploy new Development Environment]({{site.baseurl}}/images/clay0x7bd000308m50jmmgnga.md/1bwc1jm_r.gif)
+![Figure 11: Dialog to deploy new Development Environment](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clay0x7bd000308m50jmmgnga.md/1bwc1jm_r.gif)
 
 Figure 11: Dialog to deploy new Development Environment
 

--- a/holgerimbery/_posts/2022-12-03-extend-power-virtual-agent-with-azure-cognitive-services-eab95018b7f6.md
+++ b/holgerimbery/_posts/2022-12-03-extend-power-virtual-agent-with-azure-cognitive-services-eab95018b7f6.md
@@ -31,7 +31,7 @@ PVA has a built-in topic that can serve as a hook to the outside world, the "Fal
 
 ## Activate the "Fallback" topic
 
-![Figure 2: Activate the "Fallback" topic]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/7d-bbsgxq.png)
+![Figure 2: Activate the "Fallback" topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/7d-bbsgxq.png)
 
 Figure 2: Activate the "Fallback" topic
 
@@ -39,7 +39,7 @@ To activate the "Fallback" system topic, go to Settings within the editing canva
 
 After activating the topic, you will find it within "topics".
 
-![Figure 3: activated fallback topic]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/ugat3hgo2.png)
+![Figure 3: activated fallback topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/ugat3hgo2.png)
 
 Figure 3: activated fallback topic
 
@@ -62,7 +62,7 @@ This example will integrate a FAQ Database on "growing chilies". Data from a ran
 
 We created a new project on [Azure Language Studio](https://language.cognitive.azure.com/home)  and chose "Custom Question Answering".
 
-![Figure 4: Create a new Custom Question Answering Project]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/nrqckwgic.jpg)
+![Figure 4: Create a new Custom Question Answering Project](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/nrqckwgic.jpg)
 
 Figure 4: Create a new Custom Question Answering Project
 
@@ -78,19 +78,19 @@ Figure 4: Create a new Custom Question Answering Project
 | --- | --- |
 | Growing Chillies | [https://www.greenhousesensation.co.uk/growing-chillies-faq/](https://www.greenhousesensation.co.uk/growing-chillies-faq/) |
 
-![Figure 5: Add URL of FAQs]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/ivh0-ynnf.jpg)
+![Figure 5: Add URL of FAQs](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/ivh0-ynnf.jpg)
 
 Figure 5: Add URL of FAQs
 
 Language Studio will now import your FAQs into the project and gives you single and multiturn Question and Answer pairs.
 
-![Figure 6: Question and Answer pairs in Knowledge Base]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/_armxwuhi.jpg)
+![Figure 6: Question and Answer pairs in Knowledge Base](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/_armxwuhi.jpg)
 
 Figure 6: Question and Answer pairs in Knowledge Base
 
 To use the imported content, we need to clean up the answers and make them usable for a bot. We must remove pictures and links if our bot is a voice bot.
 
-![Figure 7: Add alternate phrases]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/nq-y9ppgr.jpg)
+![Figure 7: Add alternate phrases](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/nq-y9ppgr.jpg)
 
 Figure 7: Add alternate phrases
 
@@ -98,13 +98,13 @@ To make the Answering more fluent, we will add variations to each question.
 
 And deploy the knowledge base.
 
-![Figure 8: Select "Deploy" on the left side and press "deploy" on top to deploy]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/xkbv50ojw.jpg)
+![Figure 8: Select "Deploy" on the left side and press "deploy" on top to deploy](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/xkbv50ojw.jpg)
 
 Figure 8: Select "Deploy" on the left side and press "deploy" on top to deploy
 
 After deploying the knowledge base, we press "Get prediction URL", and we note down the Site URL(Red) and the Account Key (Yellow); we will use both later in Power Automate.
 
-![Figure 9: Retrieve the Site URL and Account Key]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/i16r0pr4i.jpg)
+![Figure 9: Retrieve the Site URL and Account Key](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/i16r0pr4i.jpg)
 
 Figure 9: Retrieve the Site URL and Account Key
 
@@ -114,7 +114,7 @@ We jump back into your newly created "Fallback" Topic and remove the "Escalate" 
 
 After deleting the nodes, we create a new "Call an action" node.
 
-![Figure 10: Create a new Call for an action node]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/uviczacgu.png)
+![Figure 10: Create a new Call for an action node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/uviczacgu.png)
 
 Figure 10: Create a new Call for an action node
 
@@ -122,37 +122,37 @@ Power Automate will open, and we can create a new flow.
 
 First, we rename the flow and define the input.
 
-![Figure 11: Define Input]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/8u5cieypk.png)
+![Figure 11: Define Input](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/8u5cieypk.png)
 
 Figure 11: Define Input
 
 To determine the language of the question, we will initialize a new variable, "QuestionLanguage". We will use it to store the language code.
 
-![Figure 12: Initialize variable]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/uivkxxcho.png)
+![Figure 12: Initialize variable](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/uivkxxcho.png)
 
 Figure 12: Initialize variable
 
 Create a new node by searching "Microsoft Translator V2" and selecting "Detect language", and set Text to the content of the variable "UnrecognisedUserInput".
 
-![Figure 13: Create Detect Language Node]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/z6pj8xvgj.png)
+![Figure 13: Create Detect Language Node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/z6pj8xvgj.png)
 
 Figure 13: Create Detect Language Node
 
 We use a set Variable Node to store the output of "detect language" into the "QuestionLanguage" Variable
 
-![Figure 14: Initialize Variable QuestionLanguage]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/tb4le7yz1.png)
+![Figure 14: Initialize Variable QuestionLanguage](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/tb4le7yz1.png)
 
 Figure 14: Initialize Variable QuestionLanguage
 
 with a translate text node (Microsoft Translator V2); we translate the content of "UnrecognizedUserInput" to English.
 
-![Figure 15: Translate to English]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/siemo5faq.png)
+![Figure 15: Translate to English](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/siemo5faq.png)
 
 Figure 15: Translate to English
 
 Create a new node by searching "Language - Question Answering" and selecting "Generate answer from Project".
 
-![Figure 16: Create Node]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/veunyzdfl.png)
+![Figure 16: Create Node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/veunyzdfl.png)
 
 Figure 16: Create Node
 
@@ -160,31 +160,31 @@ We noted the account Key and Site URL earlier in this guide; we use the values n
 
 Set "Question" to the output of the translation node.
 
-![Figure 17: Generate Answers from Project]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/zgjtxgraz.png)
+![Figure 17: Generate Answers from Project](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/zgjtxgraz.png)
 
 Figure 17: Generate Answers from Project
 
 Next, Initialize a new variable with a name, e.g., "CQA\_Answer"
 
-![Figure 18: Initialize Variable CQA_Answer]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/vbptlpszz.png)
+![Figure 18: Initialize Variable CQA_Answer](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/vbptlpszz.png)
 
 Figure 18: Initialize Variable CQA\_Answer
 
 A "Apply to each" Node with a "Translation" and a "set Variable" action will translate back to the language the question was asked in.
 
-![Figure 19: Apply to each Node with two actions]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/uax_rxwv_.png)
+![Figure 19: Apply to each Node with two actions](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/uax_rxwv_.png)
 
 Figure 19: Apply to each Node with two actions
 
 Finally, we adjust the Return Value to the content of the "CQA\_Answer" Variable.
 
-![Figure 20: Return Value with Content of CQA_Answer Variable]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/cdbcw4myu.png)
+![Figure 20: Return Value with Content of CQA_Answer Variable](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/cdbcw4myu.png)
 
 Figure 20: Return Value with Content of CQA\_Answer Variable
 
 After saving the flow, we can select the flow in the action node, adjust the input, and create a message node to display the output of the flow.
 
-![Figure 21: Complete Topic with Power Automate Flow]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/zbmcqzu6k.png)
+![Figure 21: Complete Topic with Power Automate Flow](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/zbmcqzu6k.png)
 
 Figure 21: Complete Topic with Power Automate Flow
 
@@ -192,7 +192,7 @@ The flow will result in the following:
 
 A question asked to the bot without a topic in PVA will end up in the "Fallback" topic. Custom Question Answering will help with the answer, even to a question not asked in English.
 
-![Figure 22: Result: multilingual QNA]({{site.baseurl}}/images/clb7zhrzm000n08lcher16dpp.md/r6envbs8n.png)
+![Figure 22: Result: multilingual QNA](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clb7zhrzm000n08lcher16dpp.md/r6envbs8n.png)
 
 Figure 22: Result: multilingual QNA
 

--- a/holgerimbery/_posts/2022-12-10-give-your-bots-a-voice.md
+++ b/holgerimbery/_posts/2022-12-10-give-your-bots-a-voice.md
@@ -44,7 +44,7 @@ To use this Kickstarter and explore this topic, you need to sign up for [Voice.A
 
 Let's give the (Power Virtual Agents) Bot a voice. Retrieve your Web channel Secret (in PVA-UI: Settings/Security/Web Channel Security)
 
-![Figure 0.1: retrieve your Web channel Secret]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/eprxmtgqc.webp)
+![Figure 0.1: retrieve your Web channel Secret](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/eprxmtgqc.webp)
 
 Figure 0.1: retrieve your Web channel Secret
 
@@ -54,21 +54,21 @@ then go to your Voice.AI Configuration Interface.
 
 Add Bot
 
-![Figure 0.2: Add details for your bot.]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/ssg2myt3b.webp)
+![Figure 0.2: Add details for your bot.](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/ssg2myt3b.webp)
 
 Figure 0.2: Add details for your Bot.
 
-![Figure 0.3: Select TTS, STT and Voice Font]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/aipvyfaa8.webp)
+![Figure 0.3: Select TTS, STT and Voice Font](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/aipvyfaa8.webp)
 
 Figure 0.3: Select TTS, STT, and Voice Font
 
 Configure Routing
 
-![Figure 0.4: configure routing "inbound"]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/kcvttvbvi.webp)
+![Figure 0.4: configure routing "inbound"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/kcvttvbvi.webp)
 
 Figure 0.4: configure routing "inbound"
 
-![Figure 0.5: configure routing "transfer"]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/ojrjtgtox.webp)
+![Figure 0.5: configure routing "transfer"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/ojrjtgtox.webp)
 
 Figure 0.5: configure routing "transfer"
 
@@ -95,7 +95,7 @@ If your Bot serves several phone lines, e.g., for different purposes (sales, cus
 
 In PVA, you can retrieve both IDs via a small composer integration and create a new composer topic.
 
-![Figure 0.6: new topic in composer]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/ta8sbucrb.png)
+![Figure 0.6: new topic in composer](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/ta8sbucrb.png)
 
 Figure 0.6: new topic in the Composer
 
@@ -103,7 +103,7 @@ Follow the steps to install Bot framework Composer and connect to Power Virtual 
 
 Create a new "Dialog" in Bot framework Composer, and select event-driven and event received as options.
 
-![Figure 1: Create a new "Event received" dialog in Composer]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/fbun6wpp-.png)
+![Figure 1: Create a new "Event received" dialog in Composer](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/fbun6wpp-.png)
 
 Figure 1: Create a new "Event received" dialog in Composer
 
@@ -111,17 +111,17 @@ Figure 1: Create a new "Event received" dialog in Composer
 
 Go back to Power Virtual Agents UI and create two variables within a new topic for each of them. This feels a little dirty to do so, but it is the way to do it before we all get the new unified authoring canvas we see in the preview.
 
-![Figure 2: Create a variable bot.caller in PVA]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/s5lkvdwhn.png)
+![Figure 2: Create a variable bot.caller in PVA](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/s5lkvdwhn.png)
 
 Figure 2: Create a variable bot.caller in PVA
 
 ensure you create a "bot" variable and select "external sources can set values".
 
-![Figure 3.0: variable as "Bot" variable ]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/bbznw5mo3.png)
+![Figure 3.0: variable as "Bot" variable ](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/bbznw5mo3.png)
 
 Figure 3.0: variable as "Bot" variable
 
-![Figure 3: Create a variable bot.callee]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/fn9amyh37.png)
+![Figure 3: Create a variable bot.callee](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/fn9amyh37.png)
 
 Figure 3: Create a variable bot.callee
 
@@ -129,7 +129,7 @@ and back to the Composer and create the flow in your newly created "dialog"
 
 #### Create dialog flow with Composer
 
-![Figure 4: Create Composer Flow to extract caller ID from channeldata]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/2yrubo81u.png)
+![Figure 4: Create Composer Flow to extract caller ID from channeldata](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/2yrubo81u.png)
 
 Figure 4: Create Composer Flow to extract caller ID from channeldata
 
@@ -137,7 +137,7 @@ Nothing special, create a switch and three "set a property node" (to manipulate 
 
 You can check the adaptive code in Bot framework Composer by selecting show code in the canvas.
 
-![Figure 5: check if condition is true]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/dww1dqc4d.png)
+![Figure 5: check if condition is true](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/dww1dqc4d.png)
 
 Figure 5: check if the condition is true
 
@@ -151,7 +151,7 @@ We can use the newly created variables everywhere (messages, as input for Power 
 
 Another Dialog you can create with the Composer is a Hangup to close the phone line after a successful dialog with a user. Therefore you select Send Activity as a Dialog event.
 
-![Figure 6: hangup dialog]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/33riopihf.png)
+![Figure 6: hangup dialog](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/33riopihf.png)
 
 Figure 6: hangup dialog
 
@@ -161,7 +161,7 @@ Why not integrate a feedback system and perform a clean hangup after the user co
 
 It would be best if you created a third Composer dialog to play music, announcements, or fancy jingles. Your sound file needs to be accessible as a public URL.
 
-![Figure 7: playsound dialog]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/c0zaakhlr.png)
+![Figure 7: playsound dialog](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/c0zaakhlr.png)
 
 Figure 7: playsound dialog
 
@@ -171,7 +171,7 @@ You could analyze the sentiment of the caller to hand over to an agent or when t
 
 This can be done without the Composer. You only need to create a new topic without trigger phrases and link to it from other topics.
 
-![Figure 8: Calltransfer Topic]({{site.baseurl}}/images/clbhy3eik05fcmlnvhhvq7v8n.md/cpp46yrkn.png)
+![Figure 8: Calltransfer Topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbhy3eik05fcmlnvhhvq7v8n.md/cpp46yrkn.png)
 
 Figure 8: Calltransfer Topic
 

--- a/holgerimbery/_posts/2022-12-17-use-crm-data-in-your-power-virtual-agent-voice-bot.md
+++ b/holgerimbery/_posts/2022-12-17-use-crm-data-in-your-power-virtual-agent-voice-bot.md
@@ -28,7 +28,7 @@ Create a simple list with the following columns:
 title, name, surname, phonenumber, customernumber
 ```
 
-![Figure 1: Create list in a sharepoint]({{site.baseurl}}/images/clbry6f1208l0gwnvand88iit.md/1nfphfblu.png)
+![Figure 1: Create list in a sharepoint](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbry6f1208l0gwnvand88iit.md/1nfphfblu.png)
 
 Figure 1: Create a list in SharePoint
 
@@ -36,25 +36,25 @@ Figure 1: Create a list in SharePoint
 
 Next, we create a new Power Automate flow to fetch the calling customers' data from the list; we use the caller's phone number - [we already extracted it from the channel data](https://the.cognitiveservices.ninja/give-your-bots-a-voice#heading-callercallee-ids) - as input for the flow.
 
-![Figure 2: Create a action node with input and outputs]({{site.baseurl}}/images/clbry6f1208l0gwnvand88iit.md/ixxhkoign.png)
+![Figure 2: Create a action node with input and outputs](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbry6f1208l0gwnvand88iit.md/ixxhkoign.png)
 
 Figure 2: Create an action node with input and outputs
 
 First, we define "phonenumber" as an input in Power Automate
 
-![Figure 3: Input variable]({{site.baseurl}}/images/clbry6f1208l0gwnvand88iit.md/nxsdmqm5h.png)
+![Figure 3: Input variable](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbry6f1208l0gwnvand88iit.md/nxsdmqm5h.png)
 
 Figure 3: Input variable
 
 Next, we initialize four variables as temporary storage for our CRM data.
 
-![Figure 4: Create four variables]({{site.baseurl}}/images/clbry6f1208l0gwnvand88iit.md/sxbwetmjk.png)
+![Figure 4: Create four variables](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbry6f1208l0gwnvand88iit.md/sxbwetmjk.png)
 
 Figure 4: Create four variables
 
 Next, the "get details from (SharePoint) list" action fetches the calling customers' data.
 
-![Figure 5: Get data from the SharePoint list]({{site.baseurl}}/images/clbry6f1208l0gwnvand88iit.md/uinkr2kxn.png)
+![Figure 5: Get data from the SharePoint list](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbry6f1208l0gwnvand88iit.md/uinkr2kxn.png)
 
 Figure 5: Get data from the SharePoint list
 
@@ -83,17 +83,17 @@ phonenumber eq 'phonenumber'
 
 The array we get as an output of that step will be used to append the created variables via "Apply to each".
 
-![Figure 6: store sharepoint list data in string variables]({{site.baseurl}}/images/clbry6f1208l0gwnvand88iit.md/ni5efnpwf.png)
+![Figure 6: store sharepoint list data in string variables](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbry6f1208l0gwnvand88iit.md/ni5efnpwf.png)
 
 Figure 6: store SharePoint list data in string variables
 
 ## Usage of CRM Data
 
-![Figure 7: make data globally visible]({{site.baseurl}}/images/clbry6f1208l0gwnvand88iit.md/7rzzksojp.png)
+![Figure 7: make data globally visible](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbry6f1208l0gwnvand88iit.md/7rzzksojp.png)
 
 Figure 7: make data globally visible
 
-![Figure 7.1: make data globally visible]({{site.baseurl}}/images/clbry6f1208l0gwnvand88iit.md/qbdme7gib.png)
+![Figure 7.1: make data globally visible](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clbry6f1208l0gwnvand88iit.md/qbdme7gib.png)
 
 Figure 7.1: make data globally visible
 

--- a/holgerimbery/_posts/2022-12-31-dynamics-365-customer-service-with-power-virtual-agents-part-1-automation-with-text-chat.md
+++ b/holgerimbery/_posts/2022-12-31-dynamics-365-customer-service-with-power-virtual-agents-part-1-automation-with-text-chat.md
@@ -31,13 +31,13 @@ Imagine a situation where your virtual agent is incapable of solving a query of 
 
 First, we need to modify the default "Escalate" topic to display a meaningful message and handover to the human.
 
-![Figure 1: standard escalate topic]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/nn3u9hc1g.png)
+![Figure 1: standard escalate topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/nn3u9hc1g.png)
 
 Figure 1: standard escalate topic
 
 Modify the "Message" node with a meaningful message and insert a new "Transfer to Agent" node. By now, we leave the handover to the agent node empty, but this is where you could insert a summary for the human agent.
 
-![Figure 2: modified escalate topic]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/j6gypwqcb.png)
+![Figure 2: modified escalate topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/j6gypwqcb.png)
 
 Figure 2: modified escalate topic
 
@@ -45,7 +45,7 @@ Figure 2: modified escalate topic
 
 After creating your Power Virtual Agent and modifying your "escalate" topic, it is time to publish your work to make it visible to the outside world.
 
-![Figure 3: Publish your bot]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/qlihh1s2m.png)
+![Figure 3: Publish your bot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/qlihh1s2m.png)
 
 Figure 3: Publish your bot
 
@@ -57,34 +57,34 @@ It would be best if you had a working Dynamics 365 Customer Service environment 
 
 First, we need to activate Agent Transfer with Omnichannel.
 
-![Figure 4: Configure Omnichannel]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/oo2ctf9vp.png)
+![Figure 4: Configure Omnichannel](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/oo2ctf9vp.png)
 
 Figure 4: Configure Omnichannel
 
-![Figure 5: Press enable]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/kw5pqxjcb.png)
+![Figure 5: Press enable](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/kw5pqxjcb.png)
 
 Figure 5: Press enable
 
 We enable voice as we will use it in the second part of this Kickstarter.  
 If there is no active subscription for D365 Customer Service, we can enable a trial and select the created environment to use with Omnichannel.
 
-![Figure 6: Start a trial if needed]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/gtsnijxan.png)
+![Figure 6: Start a trial if needed](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/gtsnijxan.png)
 
 Figure 6: Start a trial if needed
 
-![Figure 7: Enter your email address]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/fnro11b1i.png)
+![Figure 7: Enter your email address](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/fnro11b1i.png)
 
 Figure 7: Enter your email address
 
-![Figure 8: Launch trial]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/mqhhrbelb.png)
+![Figure 8: Launch trial](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/mqhhrbelb.png)
 
 Figure 8: Launch trial
 
-![Figure 9: Remember your D365 URL]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/hvtohbkt-.png)
+![Figure 9: Remember your D365 URL](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/hvtohbkt-.png)
 
 Figure 9: Remember your D365 URL
 
-![Figure 10: Select your new environment]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/3fm5nprrh.png)
+![Figure 10: Select your new environment](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/3fm5nprrh.png)
 
 Figure 10: Select your new environment
 
@@ -92,29 +92,29 @@ Figure 10: Select your new environment
 
 After configuring these initial steps, we need to create an Application Registration in our Azure Active Directory. We go to the [Azure Portal](https://aad.portal.azure.com) and select Application registrations and "+Add".
 
-![Figure 11: Select App registrations]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/f4604026-1ab5-4efb-a37f-4a7219baadf1.png)
+![Figure 11: Select App registrations](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/f4604026-1ab5-4efb-a37f-4a7219baadf1.png)
 
 Figure 11: Select App registrations
 
 We give it a speaking name and select "Accounts in any organizational directory".
 
-![Figure 12: Configure App registration]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/c2eltgc_d.png)
+![Figure 12: Configure App registration](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/c2eltgc_d.png)
 
 Figure 12: Configure App registration
 
 After saving, we can get the Application ID of the Registration (red)
 
-![Figure 13: Remember your Application ID]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/mg7srpcop.png)
+![Figure 13: Remember your Application ID](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/mg7srpcop.png)
 
 Figure 13: Remember your Application ID
 
 and paste this ID to our Agent Handover Configuration in Power Virtual Agent.
 
-![Figure 14: paste in your Application ID]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/zvexalhyt.png)
+![Figure 14: paste in your Application ID](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/zvexalhyt.png)
 
 Figure 14: paste in your Application ID
 
-![Figure 15: find your bot connected ]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/-8rmwaros.png)
+![Figure 15: find your bot connected ](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/-8rmwaros.png)
 
 Figure 15: find your bot connected
 
@@ -126,13 +126,13 @@ We need to add some extensions to our environment, to add some features, but eve
 
 Install [Omnichannel Power Virtual Agent extension](https://appsource.microsoft.com/product/dynamics-365/mscrm.omnichannelpvaextension).
 
-![Figure 16: install extensions ]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/vethbfewa.png)
+![Figure 16: install extensions ](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/vethbfewa.png)
 
 Figure 16: Install extensions
 
 If you still see the following warning after installing the Omnichannel Power Virtual Agent extension and don't need voice capabilities, you can safely ignore it.
 
-![Figure 17: ignore warning]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/vxtmolk08.png)
+![Figure 17: ignore warning](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/vxtmolk08.png)
 
 Figure 17: ignore the warning
 
@@ -153,13 +153,13 @@ Next, we will create a Queue, a Workstream, and Ruleset.
 
 First, go to https://yourtenant.crm.dynamics.com/apps
 
-![Figure 18: Go to your D365 Dashboard]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/g2csyxxri.png)
+![Figure 18: Go to your D365 Dashboard](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/g2csyxxri.png)
 
 Figure 18: Go to your D365 Dashboard
 
 Select the "Customer Service admin center App"
 
-![Figure 19: Check bots' existence ]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/89t3l0c2j.png)
+![Figure 19: Check bots' existence ](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/89t3l0c2j.png)
 
 Figure 19: Check bots' existence
 
@@ -169,17 +169,17 @@ We create a separate Queue for Customers asking for human-to-human interaction.
 
 We select the Type "Messaging" as a queue type
 
-![Figure 20: Create a queue]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/5gh12bayc.png)
+![Figure 20: Create a queue](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/5gh12bayc.png)
 
 Figure 20: Create a queue
 
-![Figure 21: see "users missing" message]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/uadgecnli.png)
+![Figure 21: see "users missing" message](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/uadgecnli.png)
 
 Figure 21: see the "users missing" message
 
 and add some agents after completing it.
 
-![Figure 22: add at least one user]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/bjop_s-mg.png)
+![Figure 22: add at least one user](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/bjop_s-mg.png)
 
 Figure 22: add at least one user
 
@@ -187,7 +187,7 @@ Figure 22: add at least one user
 
 After creating the first queue, we generate a workstream to select the Work distribution mode and the fallback queue.
 
-![Figure 23: Create and configure a workstream]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/xabayte1t.png)
+![Figure 23: Create and configure a workstream](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/xabayte1t.png)
 
 Figure 23: Create and configure a workstream
 
@@ -195,19 +195,19 @@ Next, we create a chat widget; you could use a different, more customizable chat
 
 Click "Set up chat" and configure it accordingly to the screenshots.
 
-![Figure 24: see "live chat required" message]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/pgid3csup.png)
+![Figure 24: see "live chat required" message](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/pgid3csup.png)
 
 Figure 24: see "live chat required" message
 
-![Figure 25: configure live chat - part 1]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/uozmgig5l.png)
+![Figure 25: configure live chat - part 1](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/uozmgig5l.png)
 
 Figure 25: configure live chat - part 1
 
-![Figure 26: configure live chat - part 2]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/cnguxjku7.png)
+![Figure 26: configure live chat - part 2](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/cnguxjku7.png)
 
 Figure 26: configure live chat - part 2
 
-![Figure 27: configured live chat]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/knw3awfl1.png)
+![Figure 27: configured live chat](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/knw3awfl1.png)
 
 Figure 27: configured live chat
 
@@ -215,7 +215,7 @@ Figure 27: configured live chat
 
 Next, we create a ruleset for handling the users.
 
-![Figure 28: create a ruleset]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/ae_wje1uo.png)
+![Figure 28: create a ruleset](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/ae_wje1uo.png)
 
 Figure 28: Create a ruleset
 
@@ -223,7 +223,7 @@ and create a new rule.
 
 We do not need to configure a condition, as we want to allow every user to enter the queue and assume you have a 24/7 service.
 
-![Figure 29: create a rule]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/0urueq6dz.png)
+![Figure 29: create a rule](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/0urueq6dz.png)
 
 Figure 29: Create a rule
 
@@ -231,7 +231,7 @@ Figure 29: Create a rule
 
 We add our bot via smart assist bots' settings in the Advanced settings area.
 
-![Figure 30: Add bot to workstream]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/kr9fw0qvel.png)
+![Figure 30: Add bot to workstream](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/kr9fw0qvel.png)
 
 Figure 30: Add the bot to the workstream
 
@@ -240,19 +240,19 @@ Figure 30: Add the bot to the workstream
 We need to add a first context variable to the workstream.  
 We will use the va\_Scope Variable.
 
-![Figure 31: test the chat, to display the context variables]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/38ogxqf_c.png)
+![Figure 31: test the chat, to display the context variables](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/38ogxqf_c.png)
 
 Figure 31: test the chat to display the context variables
 
-![Figure 32: see the context variables]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/8a4wrtdl6.png)
+![Figure 32: see the context variables](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/8a4wrtdl6.png)
 
 Figure 32: see the context variables
 
-![Figure 33: add context variables]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/3wgxhfnhy.png)
+![Figure 33: add context variables](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/3wgxhfnhy.png)
 
 Figure 33: add context variables
 
-![Figure 34: Create context variable]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/cvyxqzfgf.png)
+![Figure 34: Create context variable](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/cvyxqzfgf.png)
 
 Figure 34: Create context variable
 
@@ -262,7 +262,7 @@ Let's test the handover.
 
 Go to your workstream, copy the code for the snippet, create an empty HTML-File and paste the copied code into the body.
 
-![Figure 35: Copy code snippet]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/60fdf04b-15f7-444e-8ac1-5e4d5b5882b4.png)
+![Figure 35: Copy code snippet](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/60fdf04b-15f7-444e-8ac1-5e4d5b5882b4.png)
 
 Figure 35: Copy code snippet
 
@@ -283,31 +283,31 @@ You will end up with something looking like this.
 
 Open the HTML File with your Browser and start chatting.
 
-![Figure 36: start the dialog]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/a7e6c3f7-b9fe-40f6-98c7-9adbdf809679.png)
+![Figure 36: start the dialog](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/a7e6c3f7-b9fe-40f6-98c7-9adbdf809679.png)
 
 Figure 36: start the dialog
 
 Ask the bot for a human agent.
 
-![Figure 37: ask for agent]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/pcm67bgti.png)
+![Figure 37: ask for agent](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/pcm67bgti.png)
 
 Figure 37: ask for an agent
 
 In your D365 Agent Dashboard, you should see an incoming chat and can talk to yourself.
 
-![Figure 38: answer request]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/t-u8mzubz.png)
+![Figure 38: answer request](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/t-u8mzubz.png)
 
 Figure 38: answer request
 
 The agent can see the customer's dialog with the bot on the left side.
 
-![Figure 39: Explore interface]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/usjh465yl.png)
+![Figure 39: Explore interface](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/usjh465yl.png)
 
 Figure 39: Explore the interface
 
 And can start to chat with the customer.
 
-![Figure 40: customers' view]({{site.baseurl}}/images/clcbx9q4e0430o9nv7po24gyp.md/gyjns5x3p.png)
+![Figure 40: customers' view](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcbx9q4e0430o9nv7po24gyp.md/gyjns5x3p.png)
 
 Figure 40: customers' view
 

--- a/holgerimbery/_posts/2023-01-07-dynamics-365-customer-service-with-power-virtual-agents-part-2-automation-with-voicevoice-bots.md
+++ b/holgerimbery/_posts/2023-01-07-dynamics-365-customer-service-with-power-virtual-agents-part-2-automation-with-voicevoice-bots.md
@@ -39,47 +39,47 @@ After 60 minutes, you can bring your SIP-Trunk via Azure Communication Services 
 
 Remember, even if it says preview, the combination of D365 and ACS direct routing is full GA.
 
-![]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/b8445221-f024-4eca-a9f4-ff338b5382c9.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/b8445221-f024-4eca-a9f4-ff338b5382c9.png)
 
 Go to your OmniChannel Admin Center
 
-![Figure 1: Add ACS]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/fcc45d7b-5ca1-4d3b-9f9c-da99d2076a1a.webp)
+![Figure 1: Add ACS](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/fcc45d7b-5ca1-4d3b-9f9c-da99d2076a1a.webp)
 
 Figure 1: Add ACS
 
-![Figure 2: Create a new Resource]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/f814a9a7-e57b-4c56-838f-d4893c31ec5b.webp)
+![Figure 2: Create a new Resource](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/f814a9a7-e57b-4c56-838f-d4893c31ec5b.webp)
 
 Figure 2: Create a new Resource
 
 Leave the Omnichannel Admin Center window open, open another tab for the [Azure Portal](https://portal.azure.com), and configure the SBC/Port for Direct Routing.
 
-![Figure 3: Create a new Session Border Controller Configuration]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/b0a3408d-0cf7-492a-8399-a900c8d1aa83.png)
+![Figure 3: Create a new Session Border Controller Configuration](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/b0a3408d-0cf7-492a-8399-a900c8d1aa83.png)
 
 Figure 3: Create a new Session Border Controller Configuration
 
-![Figure 4: enter SBC FQDN and Port]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/913eaa78-b353-4d8a-b731-87440ccd02b5.png)
+![Figure 4: enter SBC FQDN and Port](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/913eaa78-b353-4d8a-b731-87440ccd02b5.png)
 
 Figure 4: enter SBC FQDN and Port
 
-![Figure 5: and a number pattern for outbound]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/1f34e31e-63a7-43b6-9a1d-1813f013a187.png)
+![Figure 5: and a number pattern for outbound](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/1f34e31e-63a7-43b6-9a1d-1813f013a187.png)
 
 Figure 5: and a number pattern for outbound
 
 Go back to your Omnichannel Admin Center tab and configure your phone numbers.
 
-![Figure 6: Add Phone Numbers - part 1]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/ea5063e1-65bb-47f0-91f6-d63a4af1c05d.webp)
+![Figure 6: Add Phone Numbers - part 1](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/ea5063e1-65bb-47f0-91f6-d63a4af1c05d.webp)
 
 Figure 6: Add Phone Numbers - part 1
 
-![Figure 7: Add Phone Numbers - part 2]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/7a3ce02c-1cf1-41a4-8fce-b75500f5bc50.webp)
+![Figure 7: Add Phone Numbers - part 2](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/7a3ce02c-1cf1-41a4-8fce-b75500f5bc50.webp)
 
 Figure 7: Add Phone Numbers - part 2
 
-![Figure 8: Add Phone Numbers - part 3]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/702385e8-6965-4924-ae62-2c0143136b62.webp)
+![Figure 8: Add Phone Numbers - part 3](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/702385e8-6965-4924-ae62-2c0143136b62.webp)
 
 Figure 8: Add Phone Numbers - part 3
 
-![Figure 9: Add Phone Numbers - part 4]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/8fd3f705-0858-43ba-bb0b-1a65c5ba3912.webp)
+![Figure 9: Add Phone Numbers - part 4](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/8fd3f705-0858-43ba-bb0b-1a65c5ba3912.webp)
 
 Figure 9: Add Phone Numbers - part 4
 
@@ -89,17 +89,17 @@ We will modify a queue and a workstream already in place for this Kickstarter.
 
 Go to your Customer Service admin center, then to workstreams, and rename the workstream "Demo voice call workstream" to something more specific.
 
-![Figure 10: pick one of your fresh phone numbers]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/4aad757d-bcaf-42c6-9fdd-aad194cdfc9a.webp)
+![Figure 10: pick one of your fresh phone numbers](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/4aad757d-bcaf-42c6-9fdd-aad194cdfc9a.webp)
 
 Figure 10: pick one of your fresh phone numbers
 
 instead of agents, we add our bot, which we create in part 1
 
-![Figure 11: add your bot]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/f4ff067b-ab6c-48a4-8a88-223ba1e205f4.png)
+![Figure 11: add your bot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/f4ff067b-ab6c-48a4-8a88-223ba1e205f4.png)
 
 Figure 11: add your bot
 
-![Figure 12: Bot configured]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/9c7bb18a-7a75-41a6-a912-9b5eed66acc6.png)
+![Figure 12: Bot configured](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/9c7bb18a-7a75-41a6-a912-9b5eed66acc6.png)
 
 Figure 12: Bot configured
 
@@ -115,13 +115,13 @@ Follow the dialog of your bot, now on the phone, and ask, "I want to talk to an 
 
 The bot will transfer your call to a human agent, and you will see the incoming call on your agent dashboard.
 
-![Figure 13: incoming call]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/dd3a46d0-589b-46c8-a223-6b60ef93dc55.png)
+![Figure 13: incoming call](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/dd3a46d0-589b-46c8-a223-6b60ef93dc55.png)
 
 Figure 13: incoming call
 
 Press Accept and see the complete agent experience.
 
-![Figure 14: Full Agent Desktop (Dashboard)]({{site.baseurl}}/images/clclxco3q0c118jnv7w6h3ojb.md/79c27537-75b7-4d4b-84ee-999f292e05d8.png)
+![Figure 14: Full Agent Desktop (Dashboard)](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clclxco3q0c118jnv7w6h3ojb.md/79c27537-75b7-4d4b-84ee-999f292e05d8.png)
 
 Figure 14: Full Agent Desktop (Dashboard)
 

--- a/holgerimbery/_posts/2023-01-14-the-chitchat-of-the-other-kind-chatgpt-in-power-virtual-agents.md
+++ b/holgerimbery/_posts/2023-01-14-the-chitchat-of-the-other-kind-chatgpt-in-power-virtual-agents.md
@@ -35,13 +35,13 @@ To use openai, you need to create an account with them at [www.openai.com](https
 After creating an account and adding some funds as pocket money,  
 Click top right on your account and the on "View API Keys"
 
-![Figure 1: Account Settings]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/4664512c-840a-435f-ab83-0732928e4538.png)
+![Figure 1: Account Settings](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/4664512c-840a-435f-ab83-0732928e4538.png)
 
 Figure 1: Account Settings
 
 Generate a new API Key
 
-![Figure 2: Create new secret key]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/dbc8f7fd-39a2-4d29-bf3b-ed431bc339f8.png)
+![Figure 2: Create new secret key](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/dbc8f7fd-39a2-4d29-bf3b-ed431bc339f8.png)
 
 Figure 2: Create new secret key
 
@@ -53,7 +53,7 @@ Power Virtual Agent has a built-in topic that can be a hook to the outside world
 
 To activate the “Fallback” system topic, go to Settings within the editing canvas (click on the cog symbol), then System fallback, and then “+Add”.
 
-![Figure 3: activated fallback topic]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/06a5384d-111f-4ce0-bd65-66f283725526.png)
+![Figure 3: activated fallback topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/06a5384d-111f-4ce0-bd65-66f283725526.png)
 
 Figure 3: activated fallback topic
 
@@ -61,13 +61,13 @@ Figure 3: activated fallback topic
 
 Create a message box with a meaningful message and a new action.
 
-![Figure 4: Fallback topic with message and action node]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/13c47fb9-fa50-4740-9884-aa51c3b1d875.png)
+![Figure 4: Fallback topic with message and action node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/13c47fb9-fa50-4740-9884-aa51c3b1d875.png)
 
 Figure 4: Fallback topic with message and action node
 
 In Power Automate, create a new text-based variable, "UnrecognizedUserInput"
 
-![Figure 5: text variable as input]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/fb5dac90-8575-4757-900d-e3c03938f5e8.png)
+![Figure 5: text variable as input](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/fb5dac90-8575-4757-900d-e3c03938f5e8.png)
 
 Figure 5: text variable as input
 
@@ -76,25 +76,25 @@ and an HTTP Node.
  The syntax for openai is straightforward. We need to authenticate ourselves within the header and give the model, the question, the temperature, and max\_tokens as the body. \[[documentation](https://beta.openai.com/docs/api-reference/completions/create)\].  
  temperature: Higher values mean the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
 
-![Figure 6: syntax sample]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/d6d5e346-8c55-4adf-8595-a5aad0e05fa8.png)
+![Figure 6: syntax sample](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/d6d5e346-8c55-4adf-8595-a5aad0e05fa8.png)
 
 Figure 6: syntax sample
 
 I translated this to Power Automate; it will look like the following in the HTTP node.  
 The token you created above goes directly behind Bearer in the header.
 
-![Figure 7: complete HTTP Request]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/806f894e-f4f6-4ae4-a7ff-7e67808a012d.png)
+![Figure 7: complete HTTP Request](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/806f894e-f4f6-4ae4-a7ff-7e67808a012d.png)
 
 Figure 7: complete HTTP Request
 
 As a next step, we create a String variable.
 
-![Figure 8: Initialize a Variable]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/d2165238-f8d9-4a39-9794-54987a13e3b8.png)
+![Figure 8: Initialize a Variable](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/d2165238-f8d9-4a39-9794-54987a13e3b8.png)
 
 Figure 8: Initialize a Variable  
 Create a "Parse JSON node" to analyze the Body of the answer we get from openai.
 
-![Figure 9: Parse JSON]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/7e4eca1c-ee81-4113-859f-122160a3994c.png)
+![Figure 9: Parse JSON](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/7e4eca1c-ee81-4113-859f-122160a3994c.png)
 
 Figure 9: Parse JSON  
 You can use the following as a schema or generate it with the Body of the outcome of the previous step.
@@ -147,13 +147,13 @@ After this, we create an "Apply to each" node with a "Set variable"
 
 and we close by creating an output value.
 
-![Figure 10: Last step]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/3c79006b-2a35-4681-aefd-7230e0d84ca6.png)
+![Figure 10: Last step](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/3c79006b-2a35-4681-aefd-7230e0d84ca6.png)
 
 Figure 10: Last step
 
 Back to Power Virtual Agent, we adjust the created action to the correct input and output values and create a new message box to speak/display the answer on openai.
 
-![Figure 11: Completing Action Node]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/4105f3df-e4a8-407c-a5b6-38e0e9843a62.png)
+![Figure 11: Completing Action Node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/4105f3df-e4a8-407c-a5b6-38e0e9843a62.png)
 
 Figure 11: Completing Action Node
 
@@ -161,7 +161,7 @@ Figure 11: Completing Action Node
 
 Let´s test the result within our configured channels as text chat or voice with Dynamics Customer Service 365 or AudioCodes VoiceAI.
 
-![Figure 12: Output]({{site.baseurl}}/images/clcvull7h000e08lah4j09h1t.md/f6a4b736-6565-4b37-9073-305e505186c2.png)
+![Figure 12: Output](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clcvull7h000e08lah4j09h1t.md/f6a4b736-6565-4b37-9073-305e505186c2.png)
 
 Figure 12: Output
 

--- a/holgerimbery/_posts/2023-01-21-power-virtual-agents-extensions-for-dynamics-365-workaround-on-installation-hiccups.md
+++ b/holgerimbery/_posts/2023-01-21-power-virtual-agents-extensions-for-dynamics-365-workaround-on-installation-hiccups.md
@@ -21,7 +21,7 @@ toc: true
 
 You want to use Power Virtual Agent with Dynamics 365 Customer Service, and you are trying to install the extensions to activate [variables and actions](https://learn.microsoft.com/en-us/power-virtual-agents/configuration-hand-off-omnichannel#voice-based-capabilities).
 
-![Figure 1: Message to documentation for installing the extensions]({{site.baseurl}}/images/cld5wh0dz000008mpcrvo2iqt.md/236e88ce-a85a-4ac0-8215-f67758feb1ea.png)
+![Figure 1: Message to documentation for installing the extensions](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cld5wh0dz000008mpcrvo2iqt.md/236e88ce-a85a-4ac0-8215-f67758feb1ea.png)
 
 Figure 1: Message to [documentation](https://learn.microsoft.com/en-us/power-virtual-agents/configuration-hand-off-omnichannel#recommended-extensions) for installing the extensions.
 
@@ -29,7 +29,7 @@ You are following precisely the path described in the documentation,
 but you get an error message saying the solution is not compatible with your environment.  
 In my case, all language settings are on en-US, but my tenant has a location in Germany.
 
-![Figure 2: Error Message]({{site.baseurl}}/images/cld5wh0dz000008mpcrvo2iqt.md/88fe6d1e-e2a4-4d41-a4bc-314bd57a5cb8.png)
+![Figure 2: Error Message](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cld5wh0dz000008mpcrvo2iqt.md/88fe6d1e-e2a4-4d41-a4bc-314bd57a5cb8.png)
 
 Figure 2: Error Message
 
@@ -44,7 +44,7 @@ Here comes a dirty workaround to get it done in between.
 
 Open the developer tools in your browser (Edge: CTRL+SHIFT+I) and open the Network Tab. While clicking on "install", you will see an error "400"
 
-![Figure 3: error 400 while installing]({{site.baseurl}}/images/cld5wh0dz000008mpcrvo2iqt.md/415b6086-2fa3-489d-a191-b8d42d18cbcd.png)
+![Figure 3: error 400 while installing](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cld5wh0dz000008mpcrvo2iqt.md/415b6086-2fa3-489d-a191-b8d42d18cbcd.png)
 
 Figure 3: error "400" while installing.
 
@@ -54,7 +54,7 @@ Figure 3: error "400" while installing.
 
 * Search for the Body of the "POST" Request.
 
-![Figure 4: Body of "POST" Request]({{site.baseurl}}/images/cld5wh0dz000008mpcrvo2iqt.md/7d093278-17d7-40c3-ab0e-6ae48e040cbe.png)
+![Figure 4: Body of "POST" Request](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cld5wh0dz000008mpcrvo2iqt.md/7d093278-17d7-40c3-ab0e-6ae48e040cbe.png)
 
 Figure 4: Body of "POST" Request
 
@@ -62,7 +62,7 @@ Figure 4: Body of "POST" Request
 
 * find the "countryCode"; mine was set to DE,
 
-![Figure 5: countyCode ]({{site.baseurl}}/images/cld5wh0dz000008mpcrvo2iqt.md/7934ea16-8d6f-4fd6-8b5c-312740a9efe1.png)
+![Figure 5: countyCode ](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cld5wh0dz000008mpcrvo2iqt.md/7934ea16-8d6f-4fd6-8b5c-312740a9efe1.png)
 
 Figure 5: countryCode
 
@@ -80,15 +80,15 @@ You will then recognize a result code "200" in the status line.
 
 If you close the installation popup and go straight to the environment you want to install the extensions to, you will see that this "fix" was successful.
 
-![Figure 6: Successful installing the extensions.]({{site.baseurl}}/images/cld5wh0dz000008mpcrvo2iqt.md/50d6d42f-310c-478b-9975-d1c2a4278e53.png)
+![Figure 6: Successful installing the extensions.](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cld5wh0dz000008mpcrvo2iqt.md/50d6d42f-310c-478b-9975-d1c2a4278e53.png)
 
 Figure 6: Successfully installing the extensions.
 
-![Figure 7: installed variables]({{site.baseurl}}/images/cld5wh0dz000008mpcrvo2iqt.md/d3918511-24d9-420d-83bb-daf4db8d78e3.png)
+![Figure 7: installed variables](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cld5wh0dz000008mpcrvo2iqt.md/d3918511-24d9-420d-83bb-daf4db8d78e3.png)
 
 Figure 7: installed variables.
 
-![Figure 8: Installed actions.]({{site.baseurl}}/images/cld5wh0dz000008mpcrvo2iqt.md/aa62e88f-978c-4541-90b9-9cb71908218c.png)
+![Figure 8: Installed actions.](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cld5wh0dz000008mpcrvo2iqt.md/aa62e88f-978c-4541-90b9-9cb71908218c.png)
 
 Figure 8: Installed actions.
 

--- a/holgerimbery/_posts/2023-01-28-multilingual-ivr-replacement-for-dynamics-365-customer-service-voice-bot.md
+++ b/holgerimbery/_posts/2023-01-28-multilingual-ivr-replacement-for-dynamics-365-customer-service-voice-bot.md
@@ -32,7 +32,7 @@ The basic idea behind our concierge is to have a cascade of bots living in separ
 
 We start with a selector for the language and forward the outcome to a queue for that specific language. You could create another bot for that queue or bring human agents to that queue. This mechanism can be used for a cascade of bots with different skills in several languages and can be your foundation of a bot factor in front of your human agents.
 
-![Figure 1: Architecture]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/d3b39795-75c9-48cd-a6bc-42498c662b15.png)
+![Figure 1: Architecture](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/d3b39795-75c9-48cd-a6bc-42498c662b15.png)
 
 Figure 1: Architecture
 
@@ -42,7 +42,7 @@ Figure 1: Architecture
 
 Create your "concierge" bot with English (US) language in your Omnichannel-enabled environment.
 
-![Figure 2: Create a bot]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/48a8ab4a-b8a8-4216-8681-667205e637f3.png)
+![Figure 2: Create a bot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/48a8ab4a-b8a8-4216-8681-667205e637f3.png)
 
 Figure 2: Create a bot
 
@@ -50,25 +50,25 @@ Figure 2: Create a bot
 
 Create a new topic with Bot Framework Composer.
 
-![Figure 3: Create a new composer topic]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/af55aa73-f29d-4087-81f0-94d493e20d64.png)
+![Figure 3: Create a new composer topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/af55aa73-f29d-4087-81f0-94d493e20d64.png)
 
 Figure 3: Create a new composer topic
 
-![Figure 4: Add dialog]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/d50bed99-f0fa-43c6-8ee6-7734b7c62d65.png)
+![Figure 4: Add dialog](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/d50bed99-f0fa-43c6-8ee6-7734b7c62d65.png)
 
 Figure 4: Add dialog
 
-![Figure 5: Give dialog a name]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/ffa14854-420b-4545-a521-5ac7d7ec6302.png)
+![Figure 5: Give dialog a name](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/ffa14854-420b-4545-a521-5ac7d7ec6302.png)
 
 Figure 5: Give the dialog a name
 
-![Figure 6: goto BeginDialog]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/651de35e-a541-48b1-a7fd-958b953d1522.png)
+![Figure 6: goto BeginDialog](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/651de35e-a541-48b1-a7fd-958b953d1522.png)
 
 Figure 6: goto BeginDialog
 
 select the **Add** (+) node, and then select **Send a response**.
 
-![Figure 7: add "Send a response"]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/2af2dd28-0894-4a50-9174-05d7792db60f.png)
+![Figure 7: add "Send a response"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/2af2dd28-0894-4a50-9174-05d7792db60f.png)
 
 Figure 7: add "Send a response"
 
@@ -80,7 +80,7 @@ Figure 7: add "Send a response"
 
 select **Add** (+) node, point to **Ask a question**, and then choose **Multi-choice**.
 
-![Figure 8: add "Ask a question"]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/91c2e560-39f3-4b89-9b13-3069d65611e5.png)
+![Figure 8: add "Ask a question"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/91c2e560-39f3-4b89-9b13-3069d65611e5.png)
 
 Figure 8: add "Ask a question"
 
@@ -90,11 +90,11 @@ Figure 8: add "Ask a question"
 
 Select the **User input** box
 
-![Figure 9: modify user input box]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/1cc7a3f7-c469-4f79-afba-484b266c50ca.png)
+![Figure 9: modify user input box](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/1cc7a3f7-c469-4f79-afba-484b266c50ca.png)
 
 Figure 9: modify user input box
 
-![Figure 10: edit array of choices]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/c024f853-fcdc-43b7-bb80-a30c41a836c6.png)
+![Figure 10: edit array of choices](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/c024f853-fcdc-43b7-bb80-a30c41a836c6.png)
 
 Figure 10: edit array of choices
 
@@ -112,7 +112,7 @@ Array of **choices**
 
 Select the **Add** (+) node, select **Create a condition**, and then select **Branch Switch (multiple options)**
 
-![Figure 11: create conditions]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/70d1703d-7539-4848-bc4b-e61cb6ed0a9f.png)
+![Figure 11: create conditions](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/70d1703d-7539-4848-bc4b-e61cb6ed0a9f.png)
 
 Figure 11: create conditions
 
@@ -132,7 +132,7 @@ Enter here one choice per value.
 
 Select the **Add** (+) node and then select **Manage properties** &gt; **Set a property**
 
-![Figure 12: set properties]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/3f9a3604-5439-40de-a032-bd5249ac9138.png)
+![Figure 12: set properties](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/3f9a3604-5439-40de-a032-bd5249ac9138.png)
 
 Figure 12: set properties
 
@@ -158,7 +158,7 @@ The value for the virtualagent.va_CustomerLocale variable will be updated with t
 
 Select the **Add** (+) node, and then select **Begin a Power Virtual Agent topic**.
 
-![Figure 13: add a "begin a new dialog" node]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/6c29b202-3144-4cda-b713-061e0e47efe7.png)
+![Figure 13: add a "begin a new dialog" node](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/6c29b202-3144-4cda-b713-061e0e47efe7.png)
 
 Figure 13: add a "begin a new dialog" node
 
@@ -166,7 +166,7 @@ Select "Escale" in the Dialog name.
 
 Publish the bot in Bot Framework composer, go back to PVA editing canvas, refresh, find the topic and publish in PVA.
 
-![Figure 14: new composer topic in PVA]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/0bd827a0-1c47-4e54-830e-779e83677ec9.png)
+![Figure 14: new composer topic in PVA](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/0bd827a0-1c47-4e54-830e-779e83677ec9.png)
 
 Figure 14: new composer topic in PVA
 
@@ -176,7 +176,7 @@ Open the **Greeting** topic in the authoring canvas and delete everything except
 
 Select **Add node** (+), and then select **Redirect to another topic**. Choose the topic you created above.
 
-![Figure 15: modify greeting]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/226ca585-eff8-4c57-92af-52b09f5a3a46.png)
+![Figure 15: modify greeting](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/226ca585-eff8-4c57-92af-52b09f5a3a46.png)
 
 Figure 15: modify greeting
 
@@ -186,7 +186,7 @@ open the **Escalate** topic in the authoring canvas, and delete all the default 
 
 Select Add **node (+)**, select **End the conversation**, and then select **transfer to agent**.
 
-![Figure 16: escalate topic for handover]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/bf1f6e57-35f3-4918-8ad2-b791b258cbd4.png)
+![Figure 16: escalate topic for handover](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/bf1f6e57-35f3-4918-8ad2-b791b258cbd4.png)
 
 Figure 16: escalate topic for handover
 
@@ -195,13 +195,13 @@ Save and publish.
 Check your application registration on [AAD Portal](aad.portal.azure.com) and remember the Application ID.  
 (See prerequisite)
 
-![Figure 17: Application Registration]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/dac213c4-8fb3-4cc0-8457-526c13916371.png)
+![Figure 17: Application Registration](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/dac213c4-8fb3-4cc0-8457-526c13916371.png)
 
 Figure 17: Application Registration
 
 Go to **Settings**, **Agent transfer**, select **Omnichannel, enable it and configure the transfer with the Application ID.**
 
-![Figure 18: configure omnichannel]({{site.baseurl}}/images/cldfwz8y0000e0ajydlt7752t.md/ab5e3283-a64e-44a2-9db3-6c55c6f39ef2.png)
+![Figure 18: configure omnichannel](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldfwz8y0000e0ajydlt7752t.md/ab5e3283-a64e-44a2-9db3-6c55c6f39ef2.png)
 
 Figure 18: configure omnichannel
 

--- a/holgerimbery/_posts/2023-02-04-dynamics-365-customer-service-voice-channel.md
+++ b/holgerimbery/_posts/2023-02-04-dynamics-365-customer-service-voice-channel.md
@@ -25,7 +25,7 @@ After 60 minutes, you can bring your SIP-Trunk via Azure Communication Services 
 If you are in Europe, you must go with the SIP-Trunk integration. This is a straightforward and menu-based setup. Your SIP-Trunk provider should give you an FQDN of "your" Session Border Controller and a Port.  
 Even though direct routing in Azure Communication Services is still in preview, Microsoft fully supports it on a GA level if you use it with **Dynamics 365 Customer Service Enterprise**.
 
-![Figure 1: Microsofts disclaimer]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/6b47b582-97b7-4e0a-9c87-986524d5c412.png)
+![Figure 1: Microsofts disclaimer](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/6b47b582-97b7-4e0a-9c87-986524d5c412.png)
 
 Figure 1: Microsofts disclaimer
 
@@ -36,7 +36,7 @@ Figure 1: Microsofts disclaimer
 First, go to your OmniChannel Admin Center.  
 In the site map, select **Phone numbers** in **General settings**.
 
-![Figure 2: Click on "Get Started" to start]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/f48764b0-14e9-4b3f-b1cf-11b95795bfd7.png)
+![Figure 2: Click on "Get Started" to start](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/f48764b0-14e9-4b3f-b1cf-11b95795bfd7.png)
 
 Figure 2: Click on "Get Started" to
 
@@ -48,39 +48,39 @@ Figure 2: Click on "Get Started" to
 
 * Give the new resource a meaningful name.
 
-![Figure 3: Create a new resource ]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/60869aa4-5edb-4b49-9745-2f75a9697fcb.png)
+![Figure 3: Create a new resource ](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/60869aa4-5edb-4b49-9745-2f75a9697fcb.png)
 
 Figure 3: Create a new resource.
 
 Leave the Omnichannel Admin Center window open, open another tab for the [**Azure Portal**](https://portal.azure.com/), and configure the SBC/Port for Direct Routing.
 
-![Figure 4: Create a new Session Border Controller Configuration]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/b94c9a4f-b9d8-4312-b1b8-f319a5e60b9e.png)
+![Figure 4: Create a new Session Border Controller Configuration](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/b94c9a4f-b9d8-4312-b1b8-f319a5e60b9e.png)
 
 Figure 4: Create a new Session Border Controller Configuration
 
-![Figure 5: enter SBC FQDN and Port]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/0279c8da-9e3e-46d8-b166-299296d8d581.png)
+![Figure 5: enter SBC FQDN and Port](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/0279c8da-9e3e-46d8-b166-299296d8d581.png)
 
 Figure 5: enter SBC FQDN and Port
 
-![Figure 6: and a number pattern for outbound]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/55c0f812-7bb6-4587-9b01-d259b9212a1c.png)
+![Figure 6: and a number pattern for outbound](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/55c0f812-7bb6-4587-9b01-d259b9212a1c.png)
 
 Figure 6: and a number pattern for outbound
 
 Go back to your Omnichannel Admin Center tab and configure your phone numbers.
 
-![Figure 7: Add Phone Numbers - part 1]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/9289a02d-5c62-4497-b660-b3a78fda2919.png)
+![Figure 7: Add Phone Numbers - part 1](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/9289a02d-5c62-4497-b660-b3a78fda2919.png)
 
 Figure 7: Add Phone Numbers - part 1
 
-![Figure 8: Add Phone Numbers - part 2]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/b117e437-7c38-429d-9a05-604b616f82dd.png)
+![Figure 8: Add Phone Numbers - part 2](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/b117e437-7c38-429d-9a05-604b616f82dd.png)
 
 Figure 8: Add Phone Numbers - part 2
 
-![Figure 9: Add Phone Numbers - part 3]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/bd9f14b0-d0ce-479a-81cb-357c1e8169c9.png)
+![Figure 9: Add Phone Numbers - part 3](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/bd9f14b0-d0ce-479a-81cb-357c1e8169c9.png)
 
 Figure 9: Add Phone Numbers - part 3
 
-![Figure 10: Add Phone Numbers - part 4]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/473850da-e777-4a33-a0d0-68ee4d0a38b1.png)
+![Figure 10: Add Phone Numbers - part 4](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/473850da-e777-4a33-a0d0-68ee4d0a38b1.png)
 
 Figure 10: Add Phone Numbers - part 4
 
@@ -102,7 +102,7 @@ For example, I will describe how to configure a development direct routing conne
 
 #### Create a new sip connection via Voice, SIP Routing, and select MS Teams SBC
 
-![Figure 11: Create new SIP Connection]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/faaf4349-8bce-4ed8-b32a-e6b1db6b3f2b.png)
+![Figure 11: Create new SIP Connection](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/faaf4349-8bce-4ed8-b32a-e6b1db6b3f2b.png)
 
 Figure 11: Create a new SIP Connection
 
@@ -114,7 +114,7 @@ You are now required to assign a Number to the Azure Communications Resource con
 
 2. Once you have a number, navigate to the **Numbers** page of your Telnyx Mission Control Portal and assign your Azure Communications Resource connection to the desired DID, as shown below.
 
-![Figure 12: Assign numbers]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/8332fe52-56a2-4065-bf23-601310566560.png)
+![Figure 12: Assign numbers](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/8332fe52-56a2-4065-bf23-601310566560.png)
 
 Figure 12: Assign numbers
 
@@ -122,7 +122,7 @@ Figure 12: Assign numbers
 
 Create an Outbound Voice Profile and assign it to the connection you created above.
 
-![Figure 13: Assign Outbound Voice Profile]({{site.baseurl}}/images/cldpxogo006jqj1nv0ryg1vic.md/91c69d1d-8196-4b47-8027-b2075e79514c.png)
+![Figure 13: Assign Outbound Voice Profile](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldpxogo006jqj1nv0ryg1vic.md/91c69d1d-8196-4b47-8027-b2075e79514c.png)
 
 Figure 13: Assign Outbound Voice Profile
 

--- a/holgerimbery/_posts/2023-02-11-dynamics-365-customer-service-escalating-to-a-teams-user.md
+++ b/holgerimbery/_posts/2023-02-11-dynamics-365-customer-service-escalating-to-a-teams-user.md
@@ -37,7 +37,7 @@ To update the Teams phone number in the user profile, perform the following step
 
 3. Select the required user and select **Edit** to add the phone number in the **Contact info** &gt; **Office phone** field.
 
-    ![Figure 1: Add phone number in Business Phone field]({{site.baseurl}}/images/cldzxrf0h07s3o1nv92vf064m.md/9bf0a544-2fe2-48e8-81ab-014c503eff28.png)
+    ![Figure 1: Add phone number in Business Phone field](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldzxrf0h07s3o1nv92vf064m.md/9bf0a544-2fe2-48e8-81ab-014c503eff28.png)
 
     Figure 1: Add phone number in Business Phone field
 
@@ -47,13 +47,13 @@ To update the Teams phone number in the user profile, perform the following step
 
 You'll need to enable the Consult with Microsoft Teams user setting in the voice channel section to allow the agents to consult with Microsoft Teams users.
 
-![Figure 2: Enable consult with Teams Part 1]({{site.baseurl}}/images/cldzxrf0h07s3o1nv92vf064m.md/9de0e8f2-2906-4ac5-ad73-96860fd11cf2.png)
+![Figure 2: Enable consult with Teams Part 1](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldzxrf0h07s3o1nv92vf064m.md/9de0e8f2-2906-4ac5-ad73-96860fd11cf2.png)
 
 Figure 2: Enable consult with Teams Part 1
 
 scroll down to the end
 
-![Figure 3: Enable consult with Teams Part 2]({{site.baseurl}}/images/cldzxrf0h07s3o1nv92vf064m.md/99819938-40a6-463f-aec4-e3fb4a6233b1.png)
+![Figure 3: Enable consult with Teams Part 2](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cldzxrf0h07s3o1nv92vf064m.md/99819938-40a6-463f-aec4-e3fb4a6233b1.png)
 
 Figure 3: Enable consult with Teams Part 2
 

--- a/holgerimbery/_posts/2023-02-18-personalized-customer-experience-with-voice-bots-and-dynamics-365-customer-service.md
+++ b/holgerimbery/_posts/2023-02-18-personalized-customer-experience-with-voice-bots-and-dynamics-365-customer-service.md
@@ -45,7 +45,7 @@ With [**Power Virtual Agents telephony extension**](https://appsource.microsoft.
 
 With the other extension, you will get "bot.msdyn\_" variables with all information about the caller. You can find them in your PVA variables.
 
-![Figure 1: Available variables after installing the extensions]({{site.baseurl}}/images/cle9xudpl018ojcnv5uw4dewq.md/e0922ce9-2526-4b7e-98e3-893969b621c8.png)
+![Figure 1: Available variables after installing the extensions](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cle9xudpl018ojcnv5uw4dewq.md/e0922ce9-2526-4b7e-98e3-893969b621c8.png)
 
 Figure 1: Available variables after installing the extensions.
 
@@ -54,7 +54,7 @@ Figure 1: Available variables after installing the extensions.
 Right after sending the first greeting, you can check if the bot.CustomerPhoneNumber is not empty.  
 If it's empty, the caller is not sending one, or we are not in the phone channel if you use the same bot for text and voice.
 
-![Figure 2: personalized greeting]({{site.baseurl}}/images/cle9xudpl018ojcnv5uw4dewq.md/caba74d4-a254-44fa-916c-7461b388271b.png)
+![Figure 2: personalized greeting](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cle9xudpl018ojcnv5uw4dewq.md/caba74d4-a254-44fa-916c-7461b388271b.png)
 
 Figure 2: personalized greeting
 
@@ -72,11 +72,11 @@ Please consider handling exceptions like:
 
 If you want to offer a callback, a phone number is stored in the variable bot.CustomerPhoneNumber, as the caller transmitted the caller id. Just ask for confirmation that the caller wants to have the callback on the number currently used for dialing in.
 
-![Figure 3: Confirmation of user for callback]({{site.baseurl}}/images/cle9xudpl018ojcnv5uw4dewq.md/d87b9770-e969-4f41-984e-935bcca8b404.png)
+![Figure 3: Confirmation of user for callback](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cle9xudpl018ojcnv5uw4dewq.md/d87b9770-e969-4f41-984e-935bcca8b404.png)
 
 Figure 3: Confirmation of user for callback
 
-![Figure 4: Message to the user with phone number]({{site.baseurl}}/images/cle9xudpl018ojcnv5uw4dewq.md/d297c7db-a5a9-4ee2-a297-ebc66bfecfe5.png)
+![Figure 4: Message to the user with phone number](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cle9xudpl018ojcnv5uw4dewq.md/d297c7db-a5a9-4ee2-a297-ebc66bfecfe5.png)
 
 Figure 4: Message to the user with phone number
 

--- a/holgerimbery/_posts/2023-02-25-dynamics-365-customer-service-configure-call-recording-and-transcription-for-voice-bots-and-agent-dialogues.md
+++ b/holgerimbery/_posts/2023-02-25-dynamics-365-customer-service-configure-call-recording-and-transcription-for-voice-bots-and-agent-dialogues.md
@@ -39,7 +39,7 @@ to enable call recording and transcription for a workstream
 
 * open Workstreams within your "Customer Service admin center".
 
-![Figure 1: workstream overview]({{site.baseurl}}/images/clejxxccl02pl9invf4ts678x.md/cc889ebf-c29c-4204-9a01-8cad1f8fd899.png)
+![Figure 1: workstream overview](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clejxxccl02pl9invf4ts678x.md/cc889ebf-c29c-4204-9a01-8cad1f8fd899.png)
 
 Figure 1: workstream overview
 
@@ -47,7 +47,7 @@ Figure 1: workstream overview
 
 * Click on edit in the voice channel configuration.
 
-![Figure 2: voice channel configuration]({{site.baseurl}}/images/clejxxccl02pl9invf4ts678x.md/04598904-4cae-4db1-acde-cac6246c34c2.png)
+![Figure 2: voice channel configuration](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clejxxccl02pl9invf4ts678x.md/04598904-4cae-4db1-acde-cac6246c34c2.png)
 
 Figure 2: voice channel configuration
 
@@ -55,7 +55,7 @@ Figure 2: voice channel configuration
 
 * choose the feature you want to enable in the section Transcription and Recording
 
-![Figure 3: enable features]({{site.baseurl}}/images/clejxxccl02pl9invf4ts678x.md/5d337feb-02c5-4ae2-9aad-4d88e9f6047f.png)
+![Figure 3: enable features](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clejxxccl02pl9invf4ts678x.md/5d337feb-02c5-4ae2-9aad-4d88e9f6047f.png)
 
 Figure 3: enable features
 
@@ -63,7 +63,7 @@ Figure 3: enable features
 
 If the customer asks for a handover from the voice bot to a live agent, the agent will see the full transcript after taking the call, even with the customer's sentiment. If you use the "private message to agent" feature of the Power Virtual agents, relevant data from the chat with the bot are summarized.
 
-![Figure 4: Transcript in agent desktop]({{site.baseurl}}/images/clejxxccl02pl9invf4ts678x.md/f046b892-4cff-4f1e-b517-559c413de64f.webp)
+![Figure 4: Transcript in agent desktop](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clejxxccl02pl9invf4ts678x.md/f046b892-4cff-4f1e-b517-559c413de64f.webp)
 
 Figure 4: Transcript in agent desktop
 
@@ -75,25 +75,25 @@ If you want to check a call from a specific customer, for example, while working
 
 The same applies equivalently if you go via cases, accounts, etc**.**
 
-![Figure 5: select Contacts]({{site.baseurl}}/images/clejxxccl02pl9invf4ts678x.md/a92922b9-9a65-45b3-b2d5-32cc8f34bcca.png)
+![Figure 5: select Contacts](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clejxxccl02pl9invf4ts678x.md/a92922b9-9a65-45b3-b2d5-32cc8f34bcca.png)
 
 Figure 5: Select Contacts.
 
 * Find the relevant contact.
 
-![Figure 6: select a specific contact.]({{site.baseurl}}/images/clejxxccl02pl9invf4ts678x.md/f0b58012-7ff4-4d87-9792-ca4f6dd74bdf.png)
+![Figure 6: select a specific contact.](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clejxxccl02pl9invf4ts678x.md/f0b58012-7ff4-4d87-9792-ca4f6dd74bdf.png)
 
 Figure 6: select a specific contact.
 
 * Select the relevant call/chat and open the transcript with the three dots menu.
 
-![Figure 7: select the relevant call/chat]({{site.baseurl}}/images/clejxxccl02pl9invf4ts678x.md/96c5a9cf-7896-445d-877b-183291042c00.png)
+![Figure 7: select the relevant call/chat](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clejxxccl02pl9invf4ts678x.md/96c5a9cf-7896-445d-877b-183291042c00.png)
 
 Figure 7: Select the relevant call/chat.
 
 * Explore the transcript and the recording.
 
-![Figure 8: Transcript/Recording]({{site.baseurl}}/images/clejxxccl02pl9invf4ts678x.md/87988afb-5254-47a9-8d95-eb4bd14c8109.png)
+![Figure 8: Transcript/Recording](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clejxxccl02pl9invf4ts678x.md/87988afb-5254-47a9-8d95-eb4bd14c8109.png)
 
 Figure 8: Transcript/Recording
 

--- a/holgerimbery/_posts/2023-03-04-dynamics-365-customer-service-realtime-translation-to-break-barriers-in-text-chats.md
+++ b/holgerimbery/_posts/2023-03-04-dynamics-365-customer-service-realtime-translation-to-break-barriers-in-text-chats.md
@@ -62,7 +62,7 @@ googleTranslateApiClientSecret: '<please add your own google translation v2 api 
 * Click on "Manage" in the section "Real-time translation".
     
 
-![Figure 1: Select "Manage" in "Real-time translation"]({{site.baseurl}}/images/clety0boq093hrqnv8hsvcadn.md/99e74a83-8261-461f-9686-3bf549b2dcfe.png)
+![Figure 1: Select "Manage" in "Real-time translation"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clety0boq093hrqnv8hsvcadn.md/99e74a83-8261-461f-9686-3bf549b2dcfe.png)
 
 Figure 1: Select "Manage" in "Real-time translation"
 
@@ -71,7 +71,7 @@ Figure 1: Select "Manage" in "Real-time translation"
 * configure the target language and Web Resource URL you deployed. before
     
 
-![Figure 2: configure the service]({{site.baseurl}}/images/clety0boq093hrqnv8hsvcadn.md/f8aabf80-33d7-4eac-8beb-847b9e4fe71d.png)
+![Figure 2: configure the service](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clety0boq093hrqnv8hsvcadn.md/f8aabf80-33d7-4eac-8beb-847b9e4fe71d.png)
 
 Figure 2: Configure the service.
 
@@ -79,7 +79,7 @@ Figure 2: Configure the service.
 
 As an example - all dialogs are in English (in the screenshot, you see a caller in the voice channel talking to the voice bot and later to an human agent) and the translation is in realtime to Hindi.
 
-![Figure: translated voice call from English to Hindi]({{site.baseurl}}/images/clety0boq093hrqnv8hsvcadn.md/fc484653-d2a6-465e-b019-52b18fbc7b04.png)
+![Figure: translated voice call from English to Hindi](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clety0boq093hrqnv8hsvcadn.md/fc484653-d2a6-465e-b019-52b18fbc7b04.png)
 
 Figure: translated voice call from English to Hindi
 

--- a/holgerimbery/_posts/2023-03-11-power-virtual-agents-use-openai-gpt-35-as-a-helper-for-trigger-phrases-and-custom-entities.md
+++ b/holgerimbery/_posts/2023-03-11-power-virtual-agents-use-openai-gpt-35-as-a-helper-for-trigger-phrases-and-custom-entities.md
@@ -33,7 +33,7 @@ Signup for OpenAI Playground and start exploring.
 
 e.g., if you need synonyms for personal transport vehicles, ask for them.
 
-![Figure: Ask for synonyms]({{site.baseurl}}/images/clf3wyx2b000e08mpapv40pvj.md/69650784-420f-453b-b75f-746a24ec2dec.png)
+![Figure: Ask for synonyms](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clf3wyx2b000e08mpapv40pvj.md/69650784-420f-453b-b75f-746a24ec2dec.png)
 
 Figure: Ask for synonyms
 
@@ -86,7 +86,7 @@ e.g., you create a topic for giving your customers a precise answer to the quest
 Why not combine a custom entity for the vehicles with a fine list of trigger phrases?  
 Use the same method and model as above.
 
-![Figure: Ask for trigger phrases]({{site.baseurl}}/images/clf3wyx2b000e08mpapv40pvj.md/603757d2-3f2c-4210-8e62-494fc9c10a1a.png)
+![Figure: Ask for trigger phrases](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clf3wyx2b000e08mpapv40pvj.md/603757d2-3f2c-4210-8e62-494fc9c10a1a.png)
 
 Figure: Ask for trigger phrases
 

--- a/holgerimbery/_posts/2023-03-18-dynamics-365-customer-service-always-an-answer-to-every-question.md
+++ b/holgerimbery/_posts/2023-03-18-dynamics-365-customer-service-always-an-answer-to-every-question.md
@@ -26,7 +26,7 @@ Use the Dynamics 365 Customer Service function Knowledge base to create articles
 
 Use a topic to access the Knowledgebase, e.g., the fallback topic, and create a new action.
 
-![Figure: New action to search the Knowledgebase]({{site.baseurl}}/images/clfdy68r702hvr3nv1z11hmvh.md/806cd43a-562c-48e1-b77d-1d1922885508.png)
+![Figure: New action to search the Knowledgebase](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfdy68r702hvr3nv1z11hmvh.md/806cd43a-562c-48e1-b77d-1d1922885508.png)
 
 Figure: New action to search the Knowledgebase
 
@@ -40,7 +40,7 @@ The flow itself is self-explaining and ready to use for text-based chatbots but 
 
 * Open it and jump to "Append title to article text result"
 
-![Figure: Find "Append title to article text result"]({{site.baseurl}}/images/clfdy68r702hvr3nv1z11hmvh.md/7c62c896-3f8e-44dc-be49-5dc5a343460c.png)
+![Figure: Find "Append title to article text result"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfdy68r702hvr3nv1z11hmvh.md/7c62c896-3f8e-44dc-be49-5dc5a343460c.png)
 
 Figure: Find "Append title to article text result"
 
@@ -48,7 +48,7 @@ Figure: Find "Append title to article text result"
 
 * This will remove some nice formatting and a markdown based on "heading 2" which we cannot use in the voice channel.
 
-![Figure: Edit "Append title to article text result"]({{site.baseurl}}/images/clfdy68r702hvr3nv1z11hmvh.md/b5087a3c-7ea8-4a4b-87a3-22da7fdf1b9c.png)
+![Figure: Edit "Append title to article text result"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfdy68r702hvr3nv1z11hmvh.md/b5087a3c-7ea8-4a4b-87a3-22da7fdf1b9c.png)
 
 Figure: Edit "Append title to article text result"
 
@@ -74,7 +74,7 @@ If the Power Automate flow ends in a dead end, check if Dataverse search is enab
 
 * Select features and check "Search"
 
-![Figure: Dataverse Search]({{site.baseurl}}/images/clfdy68r702hvr3nv1z11hmvh.md/ac65a50b-983a-4b9a-938a-fde5fa71311a.png)
+![Figure: Dataverse Search](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfdy68r702hvr3nv1z11hmvh.md/ac65a50b-983a-4b9a-938a-fde5fa71311a.png)
 
 Figure: Dataverse Search
 

--- a/holgerimbery/_posts/2023-03-25-power-virtual-agents-gpt-based-conversation-booster-preview.md
+++ b/holgerimbery/_posts/2023-03-25-power-virtual-agents-gpt-based-conversation-booster-preview.md
@@ -41,13 +41,13 @@ Previously, if the bot could not determine the user's intent after two prompts, 
     
 * Select **Try the unified canvas (preview)**.
     
-    ![Create new bot]({{site.baseurl}}/images/clfny97200d0iswnv7pq0fmzm.md/8be9b856-c521-4899-93ed-8fad97a6fb6c.png)
+    ![Create new bot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfny97200d0iswnv7pq0fmzm.md/8be9b856-c521-4899-93ed-8fad97a6fb6c.png)
     
     Figure: Create a new bot
     
 * Give your bot a name and enter the website you want to use for retrieving data from
     
-    ![]({{site.baseurl}}/images/clfny97200d0iswnv7pq0fmzm.md/5fb7318e-13b7-4188-b184-cbcef58bdcd6.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfny97200d0iswnv7pq0fmzm.md/5fb7318e-13b7-4188-b184-cbcef58bdcd6.png)
     
 
 Figure: enter name and website

--- a/holgerimbery/_posts/2023-04-01-power-virtual-agents-create-and-edit-with-copilot-preview.md
+++ b/holgerimbery/_posts/2023-04-01-power-virtual-agents-create-and-edit-with-copilot-preview.md
@@ -32,7 +32,7 @@ You can easily create and modify bot topics with Power Virtual Agents copilot. I
  
  If you are unable to see this feature, check in Settings / General
  
- ![enable feature]({{site.baseurl}}/images/clfxvkv0c00020al7d0u85lmn.md/6f2df0b6-1fd5-4daa-a771-4a9f51a185cd.png)
+ ![enable feature](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfxvkv0c00020al7d0u85lmn.md/6f2df0b6-1fd5-4daa-a771-4a9f51a185cd.png)
 
 ## **Use copilot to create a topic**
 
@@ -43,11 +43,11 @@ When creating a new topic, you can utilize the "Create with Copilot" feature, as
 * Create a new Topic by selecting "+ New Topic" and "Create with Copilot"
     
 
-![Create a new Topic]({{site.baseurl}}/images/clfxvkv0c00020al7d0u85lmn.md/58a19e56-95d6-473d-8ab3-0174301c6d59.png)
+![Create a new Topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfxvkv0c00020al7d0u85lmn.md/58a19e56-95d6-473d-8ab3-0174301c6d59.png)
 
 Figure: Create a new topic
 
-![Create it with Copilot]({{site.baseurl}}/images/clfxvkv0c00020al7d0u85lmn.md/adee681a-6f49-4a77-9755-9220b556e9d5.png)
+![Create it with Copilot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfxvkv0c00020al7d0u85lmn.md/adee681a-6f49-4a77-9755-9220b556e9d5.png)
 
 Figure: "Create it with Copilot"
 
@@ -62,11 +62,11 @@ If you want to offer help to users with outstanding, ask the copilot to generate
 
 The result is an excellent start to work with:
 
-![AI generated dialogflow (1)]({{site.baseurl}}/images/clfxvkv0c00020al7d0u85lmn.md/0a4392ea-66f9-4377-ac74-835cd296d86b.png)
+![AI generated dialogflow (1)](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfxvkv0c00020al7d0u85lmn.md/0a4392ea-66f9-4377-ac74-835cd296d86b.png)
 
 Figure: AI-generated dialog flow (1)
 
-![AI generated dialogflow (2)]({{site.baseurl}}/images/clfxvkv0c00020al7d0u85lmn.md/a61310ed-a622-4e33-8545-f3361da5d6b0.png)
+![AI generated dialogflow (2)](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfxvkv0c00020al7d0u85lmn.md/a61310ed-a622-4e33-8545-f3361da5d6b0.png)
 
 Figure: AI-generated dialog flow (2)
 
@@ -85,14 +85,14 @@ The essential work is done; refinements can be done manually or with your copilo
 
 To use copilot to edit an existing topic, select "Edit with Copilot"
 
-![]({{site.baseurl}}/images/clfxvkv0c00020al7d0u85lmn.md/ea873cfb-a3f0-4970-ba3b-11fe14453a3d.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfxvkv0c00020al7d0u85lmn.md/ea873cfb-a3f0-4970-ba3b-11fe14453a3d.png)
 
  Tip!  
  If you have selected any nodes on your canvas, your request will be limited to those nodes.  
  For instance, if you have selected a question node, you can simply write "add a speech response" instead of "add a speech response to the question node".  
  The nodes you have selected will be displayed next to the Update button.
 
-![Edit with Copilot]({{site.baseurl}}/images/clfxvkv0c00020al7d0u85lmn.md/bc84ed52-97d0-4ab1-9902-fb78e8326a86.png)
+![Edit with Copilot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clfxvkv0c00020al7d0u85lmn.md/bc84ed52-97d0-4ab1-9902-fb78e8326a86.png)
 
 Figure: Edit with Copilot
 

--- a/holgerimbery/_posts/2023-04-08-azure-openai-services-getting-started.md
+++ b/holgerimbery/_posts/2023-04-08-azure-openai-services-getting-started.md
@@ -17,7 +17,7 @@ toc: true
 
 This is a first article of a series on Azure OpenAI Services. This article describes how to start and brings you directly to [Azure OpenAI Service Studio](https://oai.azure.com/).
 
-![Figure: OpenAI on Azure Studio]({{site.baseurl}}/images/clg7w9yjb0bizuonvaprjcpm3.md/ddcbe3b1-aa6c-44ac-a073-7c7ddb03ce6a.png)
+![Figure: OpenAI on Azure Studio](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clg7w9yjb0bizuonvaprjcpm3.md/ddcbe3b1-aa6c-44ac-a073-7c7ddb03ce6a.png)
 
 Figure: Azure OpenAI Service Studio
 
@@ -44,14 +44,14 @@ The quickest way to onboard is via [Azure OpenAI Services Studio](https://oai.az
 * Check access rights
     
 
-![Figure: onboarding message]({{site.baseurl}}/images/clg7w9yjb0bizuonvaprjcpm3.md/224e7ea3-ff32-4d49-84cd-56851ac83c54.png)
+![Figure: onboarding message](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clg7w9yjb0bizuonvaprjcpm3.md/224e7ea3-ff32-4d49-84cd-56851ac83c54.png)
 
 Figure: onboarding message
 
 * [Request Access](https://aka.ms/oai/access)
     
 
-![Figure: application form]({{site.baseurl}}/images/clg7w9yjb0bizuonvaprjcpm3.md/25d5234a-b626-4bc7-a160-95114b380836.png)
+![Figure: application form](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clg7w9yjb0bizuonvaprjcpm3.md/25d5234a-b626-4bc7-a160-95114b380836.png)
 
 Figure: application form
 
@@ -61,7 +61,7 @@ after your application, it could take some time to get your authorization.
 
 After you receive your authorization, you can create a Ressource via Azure Market Place.
 
-![Figure: Create Ressource]({{site.baseurl}}/images/clg7w9yjb0bizuonvaprjcpm3.md/37107b5c-2aee-4b3b-8028-07a70cacebd6.png)
+![Figure: Create Ressource](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clg7w9yjb0bizuonvaprjcpm3.md/37107b5c-2aee-4b3b-8028-07a70cacebd6.png)
 
 Figure: Create Ressource
 
@@ -72,7 +72,7 @@ After getting access and creating your Ressource, you can explore Azure OpenAI S
 * Create a new deployment.
     
 
-![Figure: Create a new deployment]({{site.baseurl}}/images/clg7w9yjb0bizuonvaprjcpm3.md/8ae78ba3-e480-4bc8-a0d0-bcd1fc379f74.png)
+![Figure: Create a new deployment](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clg7w9yjb0bizuonvaprjcpm3.md/8ae78ba3-e480-4bc8-a0d0-bcd1fc379f74.png)
 
 Figure: Create a new deployment
 
@@ -81,13 +81,13 @@ Figure: Create a new deployment
 * after the creation, you can start with GPT-3 Playground
     
 
-![Figure: door to playground]({{site.baseurl}}/images/clg7w9yjb0bizuonvaprjcpm3.md/06865a37-2ca7-498c-8d96-d96995b7e1d7.png)
+![Figure: door to playground](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clg7w9yjb0bizuonvaprjcpm3.md/06865a37-2ca7-498c-8d96-d96995b7e1d7.png)
 
 Figure: door to the playground
 
 Start with, e.g., parsing unstructured data
 
-![Figure: First experiment]({{site.baseurl}}/images/clg7w9yjb0bizuonvaprjcpm3.md/1443911c-86a4-4517-a9a1-0a13e7bb594c.png)
+![Figure: First experiment](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clg7w9yjb0bizuonvaprjcpm3.md/1443911c-86a4-4517-a9a1-0a13e7bb594c.png)
 
 Figure: First experiment
 

--- a/holgerimbery/_posts/2023-04-15-creating-powerful-bots-with-power-virtual-agents-natural-language-understanding-and-custom-entities.md
+++ b/holgerimbery/_posts/2023-04-15-creating-powerful-bots-with-power-virtual-agents-natural-language-understanding-and-custom-entities.md
@@ -22,7 +22,7 @@ Power Virtual Agents is a virtual digital assistant SaaS Solution that uses Natu
 
 Power Virtual Agents offers a range of pre-constructed entities, allowing it to recognize a variety of commonly used data in conversations, including ages, colors, numbers, and names. This allows the bot to understand the context of a user's input and store this information for future use.
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/00dfdc4d-a586-4843-aaa9-c2521002fa85.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/00dfdc4d-a586-4843-aaa9-c2521002fa85.png)
 
 Figure: Prebuild entities
 
@@ -36,11 +36,11 @@ For example, if you wish to create a bot to help people find parking spots, you 
 
 A closed list entity allows you to create a curated group of items. This is best suited for short, manageable lists that have essential labels. In this example, you can construct an entity that gives the bot insight into the various types of vehicles. Creating an entity will display a panel where you can name the entity, add a concise description, and input the elements you want to be included.
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/35bbddfa-47e6-41ef-aeb2-4e351a9be52a.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/35bbddfa-47e6-41ef-aeb2-4e351a9be52a.png)
 
 Figure: Closed List
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/147cbbad-9d2e-4850-a3f5-c7d6d0964e85.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/147cbbad-9d2e-4850-a3f5-c7d6d0964e85.png)
 
 Figure: Create new custom entity "vehicles"
 
@@ -54,7 +54,7 @@ When you enter items, you can:
 
 You can add synonyms to manually expand the matching logic for each item in the entity's list.
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/89a3f0b0-960e-46cf-b218-2de3ff9d6e79.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/89a3f0b0-960e-46cf-b218-2de3ff9d6e79.png)
 
 Figure: Smart matching
 
@@ -64,13 +64,13 @@ You can activate Smart matching for each entity, an element of the bot's languag
 
 A regular expression entity enables you to create a logical pattern that can be used to match and extract information from a user's input. Regex entities can identify many items, including tracking IDs, license numbers, credit card numbers, IP addresses, number plates, and more. This is helpful in cases where a user may enter data in various formats or formats that are difficult to anticipate.
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/c48ef559-b39b-4bfd-9d73-3fe884c1883b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/c48ef559-b39b-4bfd-9d73-3fe884c1883b.png)
 
 Figure: Regular expression
 
 These entities are created using a set of special characters and symbols that represent a pattern to be matched. They help find words, phrases, or numbers in a piece of text or for validating that specific criteria have been met, such as verifying a phone number or email address.
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/c44ed3c2-165d-4938-9dce-0d8539e125f3.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/c44ed3c2-165d-4938-9dce-0d8539e125f3.png)
 
 Figure: defining a regular expression
 
@@ -88,7 +88,7 @@ Now that you've given the bot the knowledge about vehicles by creating that vehi
 
 * Under **Identify**, select the entity you created in [Custom Entities](https://learn.microsoft.com/en-us/power-virtual-agents/advanced-entities-slot-filling#custom-entities).
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/09c7c9f0-8a1b-4046-8af0-5183b0895c04.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/09c7c9f0-8a1b-4046-8af0-5183b0895c04.png)
 
 Figure: picking custom entities
 
@@ -98,13 +98,13 @@ Slot filling is a natural language understanding concept that saves an extracted
 
 In the context of Power Virtual Agents, slot filling is the process of capturing user input and saving it to a variable. This variable is then used to guide the conversation in the dialog tree, allowing the bot to ask more specific questions and provide more relevant answers. For example, when the user is asked for a vehicle category, the bot will capture the user input, save it to a variable, and use it to determine the next step in the conversation. By keeping the user input, slot filling helps the bot to provide more personalized and accurate responses based on the user's specific needs.
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/eb2db175-fe94-40c6-923c-96728842f285.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/eb2db175-fe94-40c6-923c-96728842f285.png)
 
 Figure: Slot filling
 
 You can also use what is known as "proactive slot filling", where the user can specify multiple pieces of information that map to various entities. The bot can understand what data belongs to which entity automatically. In cases where it is unsure of the intended mapping, it will prompt the user to be more specific by providing choices. The user wrote, "I want to park my car" in this example. This includes the trigger phrase that the user wants to park something and provides a second piece of information—the actual type of vehicle. In this case, the bot fills in the entity for parking and the kind of vehicle.
 
-![]({{site.baseurl}}/images/clghwcxj909huh0nveiym3byb.md/1bba9ecd-00e3-4318-81b5-06d25392b027.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clghwcxj909huh0nveiym3byb.md/1bba9ecd-00e3-4318-81b5-06d25392b027.png)
 
 Figure: Result of slot filling
 

--- a/holgerimbery/_posts/2023-04-22-azure-openai-services-text-creation-and-modification.md
+++ b/holgerimbery/_posts/2023-04-22-azure-openai-services-text-creation-and-modification.md
@@ -67,7 +67,7 @@ feedback: "After calling you, one of your staff solved me issue. everything is w
 Sentiment:
 ```
 
-![Result of the experiment - feedback]({{site.baseurl}}/images/clgrwfyc005frlcnv7vmi89p6.md/fb1be3b4-e0c6-4cfb-aff8-73fbd6c36b36.png)
+![Result of the experiment - feedback](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clgrwfyc005frlcnv7vmi89p6.md/fb1be3b4-e0c6-4cfb-aff8-73fbd6c36b36.png)
 
 Figure: Result of the experiment - feedback  
 It's worth paying attention to several features in this example:
@@ -91,7 +91,7 @@ Ideas involving chatbots and customer service
 2.
 ```
 
-![Result of Generation experiment]({{site.baseurl}}/images/clgrwfyc005frlcnv7vmi89p6.md/033da7d3-1b63-4b47-9457-bb773e5e7930.png)
+![Result of Generation experiment](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clgrwfyc005frlcnv7vmi89p6.md/033da7d3-1b63-4b47-9457-bb773e5e7930.png)
 
 Figure: Result of Generation experiment
 
@@ -130,7 +130,7 @@ User: Who was the first man in space?
 Herbert:
 ```
 
-![Result of Conversation experiment]({{site.baseurl}}/images/clgrwfyc005frlcnv7vmi89p6.md/e01500e0-4048-45a5-bd7c-359a2ee28976.png)
+![Result of Conversation experiment](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clgrwfyc005frlcnv7vmi89p6.md/e01500e0-4048-45a5-bd7c-359a2ee28976.png)
 
 Figure: Result of Conversation experiment
 
@@ -158,7 +158,7 @@ This example works because the API already has a grasp of French, so there's no 
 
 The API can identify the underlying meaning of the text and rephrase it into multiple different forms. As an example of its capabilities, the API can take a section of text and form an understandable explanation for young children. This serves to demonstrate the API's comprehensive knowledge of the language.
 
-![Result of Summarization experiment]({{site.baseurl}}/images/clgrwfyc005frlcnv7vmi89p6.md/03b246a7-5f96-4523-a056-cf12d03e2a26.png)
+![Result of Summarization experiment](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clgrwfyc005frlcnv7vmi89p6.md/03b246a7-5f96-4523-a056-cf12d03e2a26.png)
 
 Figure: Result of Summarization experiment
 
@@ -172,7 +172,7 @@ While all prompts result in completions, it can be helpful to think of text comp
 Vertical farming provides a novel solution for producing food locally, reducing transportation costs and
 ```
 
-![Result of experiment Completion]({{site.baseurl}}/images/clgrwfyc005frlcnv7vmi89p6.md/181f4b42-7381-4306-8ae1-2e61e47743e7.png)
+![Result of experiment Completion](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clgrwfyc005frlcnv7vmi89p6.md/181f4b42-7381-4306-8ae1-2e61e47743e7.png)
 
 Figure: Result of experiment Completion
 

--- a/holgerimbery/_posts/2023-05-13-power-virtual-agents-find-online-content-based-topic-suggestions.md
+++ b/holgerimbery/_posts/2023-05-13-power-virtual-agents-find-online-content-based-topic-suggestions.md
@@ -37,17 +37,17 @@ Power Virtual Agents can detect and analyze the structure of documents during co
 
 First, point to the web pages or online files from which you'd like to extract content. Once the extraction is complete, you will be directed to the Suggested Topics page. Here, you will be able to review topics that were extracted from the web pages or online files. To access the Suggested Topics page, open the navigation menu and select Topics. Then, select Suggest topics. Once on the Suggested Topics page, you can add the topics to your bot for further use.
 
-![]({{site.baseurl}}/images/clhlp6q1l02g0l9nv8l11fwce.md/ed40cb87-1bd4-4cfd-85b4-a4e9334fbec8.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhlp6q1l02g0l9nv8l11fwce.md/ed40cb87-1bd4-4cfd-85b4-a4e9334fbec8.png)
 
 Figure: Suggest topics
 
 Once you have finished adding URLs to webpages and online files, click "Start" to begin the extraction process. This can take several minutes, depending on the number and complexity of the web pages or files you have added. A message will appear at the top of the screen indicating that the extraction is in progress and may take some time.
 
-![]({{site.baseurl}}/images/clhlp6q1l02g0l9nv8l11fwce.md/ec4a2acc-3dc5-49ac-bf1a-0316fa95a874.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhlp6q1l02g0l9nv8l11fwce.md/ec4a2acc-3dc5-49ac-bf1a-0316fa95a874.png)
 
 Figure: raw data
 
-![]({{site.baseurl}}/images/clhlp6q1l02g0l9nv8l11fwce.md/b5c7ce2c-6baf-48e4-843d-0f5a7cb6120f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhlp6q1l02g0l9nv8l11fwce.md/b5c7ce2c-6baf-48e4-843d-0f5a7cb6120f.png)
 
 Figure: Enter URL
 
@@ -55,7 +55,7 @@ Figure: Enter URL
     Several suggestions will appear.
     
 
-![]({{site.baseurl}}/images/clhlp6q1l02g0l9nv8l11fwce.md/6e13d686-b03a-4289-8990-f99c83c9d5cc.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhlp6q1l02g0l9nv8l11fwce.md/6e13d686-b03a-4289-8990-f99c83c9d5cc.png)
 
 Figure: Suggested
 

--- a/holgerimbery/_posts/2023-05-20-power-virtual-agents-and-powerfx-a-sneak-peek.md
+++ b/holgerimbery/_posts/2023-05-20-power-virtual-agents-and-powerfx-a-sneak-peek.md
@@ -40,7 +40,7 @@ To use a variable in a Power Fx formula, you must add a prefix to its name to in
 
 For example, to use the system variable [`Conversation.Id`](http://Conversation.Id) in a formula, you'd need to refer to it as [`System.Conversation.Id`](http://System.Conversation.Id).
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/e33e92da-801f-4002-a5d1-e9fbb9e94cb0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/e33e92da-801f-4002-a5d1-e9fbb9e94cb0.png)
 
 Figure: Set Variable Value
 
@@ -72,7 +72,7 @@ we'll use a Power Fx expression to store the customer's name and output it in ca
 * Select the box under **Save response as**, and then select the variable `Var1` and name it `customerName`.
   
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/b2474955-9137-4b45-917a-65f0e820f94b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/b2474955-9137-4b45-917a-65f0e820f94b.png)
 
 Figure: Question Node
 
@@ -85,7 +85,7 @@ Figure: Question Node
 * In the **fx** box, enter `Upper(Text(Topic.customerName))`, and then choose **Insert**.
   
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/c3ec9f2f-d193-4128-8193-10d2930687e3.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/c3ec9f2f-d193-4128-8193-10d2930687e3.png)
 
 Figure: Set Variable Value
 
@@ -94,11 +94,11 @@ Figure: Set Variable Value
 * Enter `Hello`, select **{x}**, and then select `capsName`.
   
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/30e3bf3d-5441-46fa-992d-ea5807474e28.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/30e3bf3d-5441-46fa-992d-ea5807474e28.png)
 
 Figure: Send a message to Node
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/49bb993a-1caf-4faf-adc3-21b408a54d7f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/49bb993a-1caf-4faf-adc3-21b408a54d7f.png)
 
 Figure: Result
 
@@ -117,7 +117,7 @@ In this example, the bot determines if a booking date qualifies for a discount. 
 * Select the box under **Save response as**, and then select the variable `Var1` and name it `bookingDate`.
   
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/def8438a-974b-41d7-a3a8-6412e32f1354.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/def8438a-974b-41d7-a3a8-6412e32f1354.png)
 
 Figure: Question Node
 
@@ -126,7 +126,7 @@ Figure: Question Node
 * In the **Condition** node, select the **Node menu** (**⋮**) and choose **Change to formula**.
   
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/4a9de0f9-0991-458d-94a4-1b573b7ae384.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/4a9de0f9-0991-458d-94a4-1b573b7ae384.png)
 
 Figure: Add Condition
 
@@ -135,7 +135,7 @@ Figure: Add Condition
 * Replace the contents of the **fx** box with the formula `Topic.bookingDate > (DateAdd (Now(), 14))`, and then choose **Insert**.
   
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/1e28b474-1252-470f-a835-3b5a7bfd387a.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/1e28b474-1252-470f-a835-3b5a7bfd387a.png)
 
 Figure: Formula in condition
 
@@ -144,11 +144,11 @@ Figure: Formula in condition
 * Under the **All Other Conditions** node, add a **Send a message** node and enter the message, `Sorry, you don't qualify for a discount`.
   
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/b55e4f2c-0ae8-48d1-a01d-fb002f634fea.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/b55e4f2c-0ae8-48d1-a01d-fb002f634fea.png)
 
 Figure: Full Conversation Flow
 
-![]({{site.baseurl}}/images/clhvwrsyx029408nv61zsfy8u.md/7b0a60b3-2d03-4269-b8ef-d0fff873cd4d.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clhvwrsyx029408nv61zsfy8u.md/7b0a60b3-2d03-4269-b8ef-d0fff873cd4d.png)
 
 Figure: Result
 

--- a/holgerimbery/_posts/2023-06-03-transform-your-ai-assistants-with-the-ability-to-generate-answers-perform-actions-and-additional-features-using-microsoft-power-virtual-agents.md
+++ b/holgerimbery/_posts/2023-06-03-transform-your-ai-assistants-with-the-ability-to-generate-answers-perform-actions-and-additional-features-using-microsoft-power-virtual-agents.md
@@ -32,31 +32,31 @@ Additionally, you can create custom topics that draw data from your backend syst
 * Create a new bot in the latest editing canvas and enter the first web source to get answers from
     
 
-![first external source for generative answers]({{site.baseurl}}/images/clifwxq4501iubynv6ip6awlc.md/504caebc-8b3b-4c31-be1c-0e25c2a7a71f.png)
+![first external source for generative answers](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clifwxq4501iubynv6ip6awlc.md/504caebc-8b3b-4c31-be1c-0e25c2a7a71f.png)
 
 *Figure: the first external source for generative answers*
 
 * head over to the Settings/AI Capabilities page to tailor the feature to your needs, e.g., add additional information sources.
     
 
-![]({{site.baseurl}}/images/clifwxq4501iubynv6ip6awlc.md/b48b573c-a2a3-4dac-8562-6a259c120690.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clifwxq4501iubynv6ip6awlc.md/b48b573c-a2a3-4dac-8562-6a259c120690.png)
 
 *Figure: Generative answers configuration and settings page with multiple data sources.*
 
 * scroll down to "Advanced configuration" to modify the feature, if needed
     
-    ![Advanced configuration]({{site.baseurl}}/images/clifwxq4501iubynv6ip6awlc.md/91d5d310-4c79-4f4e-aaa6-4974706dccf4.png)
+    ![Advanced configuration](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clifwxq4501iubynv6ip6awlc.md/91d5d310-4c79-4f4e-aaa6-4974706dccf4.png)
     
     *Figure: Advanced Configuration*
     
-    ![conversational boosting topic]({{site.baseurl}}/images/clifwxq4501iubynv6ip6awlc.md/b968487b-9235-49e2-b5d1-644708104b95.png)
+    ![conversational boosting topic](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clifwxq4501iubynv6ip6awlc.md/b968487b-9235-49e2-b5d1-644708104b95.png)
     
     *Figure: conversational boosting topic*  
     
 
 You will find a result similar to the screenshot below
 
-![Result]({{site.baseurl}}/images/clifwxq4501iubynv6ip6awlc.md/b4302629-3d7a-4024-b74a-83b17a593ab5.png)
+![Result](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clifwxq4501iubynv6ip6awlc.md/b4302629-3d7a-4024-b74a-83b17a593ab5.png)
 
 *Figure: Result*  
   
@@ -67,7 +67,7 @@ Please find [additional resources](https://the.cognitiveservices.ninja/series/op
 
 In a limited Preview version, bot makers can utilize generative actions capabilities to integrate their tenant APIs, enterprise-specific Microsoft Power Automate flows, or other actions into their bots. In the generative actions-tracing canvas, creators can observe how the bot evaluates and decides which tools to use and what questions to ask. The bot can comprehend the user's inquiry and search through its action library to identify which can best satisfy the request. It then automatically assembles and links them together while creating follow-up questions for the user if more information is needed.
 
-![]({{site.baseurl}}/images/clifwxq4501iubynv6ip6awlc.md/66df5ad2-42ae-4bb5-b15a-c5256f7e8e33.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clifwxq4501iubynv6ip6awlc.md/66df5ad2-42ae-4bb5-b15a-c5256f7e8e33.png)
 
 *Figure: Test generative actions tracing and watch the chain log progress.  
 *

--- a/holgerimbery/_posts/2023-06-10-creating-multilingual-chatbots-with-power-virtual-agents-3-workarounds-to-get-started.md
+++ b/holgerimbery/_posts/2023-06-10-creating-multilingual-chatbots-with-power-virtual-agents-3-workarounds-to-get-started.md
@@ -31,7 +31,7 @@ Today, Power Virtual Agents support [23 languages](https://learn.microsoft.com/e
 
 ### Using a Power Automate flow
 
-![language detection and custom question answering via Power Automate]({{site.baseurl}}/images/clipw6kkm000909labxg80bz9.md/9c2799d9-46ac-4fb6-a0e4-07363f275180.webp)
+![language detection and custom question answering via Power Automate](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clipw6kkm000909labxg80bz9.md/9c2799d9-46ac-4fb6-a0e4-07363f275180.webp)
 
 *Figure: language detection and custom question answering via Power Automate*
 
@@ -41,7 +41,7 @@ I authored an article a few months ago that provides a [step-by-step guide](http
 
 ### Use Dynamics 365 Customer Service and create a multilingual IVR for voice-enabled PVA
 
-![multiple cascaded bots]({{site.baseurl}}/images/clipw6kkm000909labxg80bz9.md/044ec5a9-bb85-46d6-8815-858159ba1663.webp)
+![multiple cascaded bots](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clipw6kkm000909labxg80bz9.md/044ec5a9-bb85-46d6-8815-858159ba1663.webp)
 
 *Figure: multiple cascade bots*
 
@@ -53,7 +53,7 @@ Begin with a language selector and forward the result to a queue designated for 
 
 ### Translation Bot on a relay
 
-![translation relay with an Azure Service Bot]({{site.baseurl}}/images/clipw6kkm000909labxg80bz9.md/dabc36f5-b268-4923-ba5b-2f0955fafa9b.jpeg)
+![translation relay with an Azure Service Bot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clipw6kkm000909labxg80bz9.md/dabc36f5-b268-4923-ba5b-2f0955fafa9b.jpeg)
 
 *Figure: translation relay with an Azure Service Bot*
 

--- a/holgerimbery/_posts/2023-06-17-dynamics-365-customer-service-design-your-own-live-chat-experience.md
+++ b/holgerimbery/_posts/2023-06-17-dynamics-365-customer-service-design-your-own-live-chat-experience.md
@@ -43,11 +43,11 @@ To utilize Live Chat Widget 2.0 and script-based customization, alter the code s
 
 The revised code snippet will appear as follows:
 
-![Code snippet]({{site.baseurl}}/images/clizx3li406ew35nvcm66477p.md/1ed6a584-69b2-48d9-920f-0367ebd71893.png)
+![Code snippet](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clizx3li406ew35nvcm66477p.md/1ed6a584-69b2-48d9-920f-0367ebd71893.png)
 
 Figure: code snippet
 
-![Resulting Chat Window]({{site.baseurl}}/images/clizx3li406ew35nvcm66477p.md/21768743-851e-4025-b3f8-2453e83046a5.png)
+![Resulting Chat Window](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clizx3li406ew35nvcm66477p.md/21768743-851e-4025-b3f8-2453e83046a5.png)
 
 Figure: Resulting Chat Window
 

--- a/holgerimbery/_posts/2023-06-24-dynamics-365-customer-service-assessing-customer-experience-with-surveys.md
+++ b/holgerimbery/_posts/2023-06-24-dynamics-365-customer-service-assessing-customer-experience-with-surveys.md
@@ -37,11 +37,11 @@ To configure a pre-conversation survey for the chat channel, follow these steps:
 
 Following these instructions, you can easily create a pre-conversation survey that users will be prompted with when accessing your chat channel widget.
 
-![activating and configuring pre-conversation survey]({{site.baseurl}}/images/clj9x6jzi0qzy4jnv8xoxde8e.md/fcf0a5d0-86c5-4b39-a71a-35fac98e56f2.png)
+![activating and configuring pre-conversation survey](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clj9x6jzi0qzy4jnv8xoxde8e.md/fcf0a5d0-86c5-4b39-a71a-35fac98e56f2.png)
 
 Figure: activating and configuring pre-conversation survey
 
-![Result]({{site.baseurl}}/images/clj9x6jzi0qzy4jnv8xoxde8e.md/a478ca59-c2fd-40ff-b8f6-27b0b6fad58d.png)
+![Result](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clj9x6jzi0qzy4jnv8xoxde8e.md/a478ca59-c2fd-40ff-b8f6-27b0b6fad58d.png)
 
 Figure: Result
 
@@ -51,11 +51,11 @@ The post-conversation survey utilizes Dynamics 365 Customer Voice to create surv
 
 See [documentation](https://learn.microsoft.com/en-us/dynamics365/customer-service/configure-post-conversation-survey?tabs=customerserviceadmincenter) for details.
 
-![activating and configuring post-conversation survey]({{site.baseurl}}/images/clj9x6jzi0qzy4jnv8xoxde8e.md/652bbe77-7fc1-4caf-b058-8851a2e14ed3.png)
+![activating and configuring post-conversation survey](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clj9x6jzi0qzy4jnv8xoxde8e.md/652bbe77-7fc1-4caf-b058-8851a2e14ed3.png)
 
 Figure: activating and configuring post-conversation survey
 
-![Result]({{site.baseurl}}/images/clj9x6jzi0qzy4jnv8xoxde8e.md/56848d36-94af-4a73-a20a-06a6e730aaa3.png)
+![Result](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clj9x6jzi0qzy4jnv8xoxde8e.md/56848d36-94af-4a73-a20a-06a6e730aaa3.png)
 
 Figure: Result
 

--- a/holgerimbery/_posts/2023-07-01-dynamics-365-customer-service-effortlessly-detect-clients-in-conversations.md
+++ b/holgerimbery/_posts/2023-07-01-dynamics-365-customer-service-effortlessly-detect-clients-in-conversations.md
@@ -77,11 +77,11 @@ single line
 
 ---
 
-![pre-conversation survey]({{site.baseurl}}/images/cljjoi85l000709l873ex3ovi.md/5f64818a-d37e-4331-9a1b-03c9cf66c7e7.png)
+![pre-conversation survey](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cljjoi85l000709l873ex3ovi.md/5f64818a-d37e-4331-9a1b-03c9cf66c7e7.png)
 
 Figure: pre-conversation survey
 
-![configuration of pre-conversation survey]({{site.baseurl}}/images/cljjoi85l000709l873ex3ovi.md/cfdeed7c-cbd8-4d64-9a85-1c498a503dc3.png)
+![configuration of pre-conversation survey](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cljjoi85l000709l873ex3ovi.md/cfdeed7c-cbd8-4d64-9a85-1c498a503dc3.png)
 
 Figure: configuration of pre-conversation survey
 

--- a/holgerimbery/_posts/2023-07-15-enhancing-customer-support-with-dynamics-365-copilot.md
+++ b/holgerimbery/_posts/2023-07-15-enhancing-customer-support-with-dynamics-365-copilot.md
@@ -36,7 +36,7 @@ Follow these steps to enable the Copilot features:
 * Operations &gt; Insights &gt; Copilot Help Pane (preview)
     
 
-![]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/c693c9f0-e5f8-4092-9eca-a7fadd66ba49.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/c693c9f0-e5f8-4092-9eca-a7fadd66ba49.png)
 
 *Figure: copilot help pane*
 
@@ -52,13 +52,13 @@ Follow these steps to enable the Copilot features:
 * **For email:** This displays the "Write an email" tab on the Copilot Help Pane (preview). Copilot assists agents in creating email responses based on the case context.
     
 
-![]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/be13a771-57f6-47b4-9316-675fd9c66981.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/be13a771-57f6-47b4-9316-675fd9c66981.png)
 
 *Figure: enable features*
 
 4\. Click Add Web Address in Web Resources to add trusted domains. You can add up to five trusted web domains for the copilot to search and generate responses. To limit the content you want Copilot to use, specify up to two levels, represented by a forward slash (/) after the .com part of the URL.
 
-![knowledge sources]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/d456b3db-513d-4b06-8c45-3737f14c0e46.png)
+![knowledge sources](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/d456b3db-513d-4b06-8c45-3737f14c0e46.png)
 
 *Figure: knowledge sources*
 
@@ -80,7 +80,7 @@ Copilot-generated case and conversation summaries enhance agent collaboration an
     
     Next, click on "Manage" in Summaries (preview).
     
-    ![summaries pane]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/7188a353-7167-481f-acb6-a398bf9b1142.png)
+    ![summaries pane](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/7188a353-7167-481f-acb6-a398bf9b1142.png)
     
     *Figure: summaries pane*
     
@@ -97,7 +97,7 @@ Copilot-generated case and conversation summaries enhance agent collaboration an
     * **On-demand, by selecting a button to summarize the conversation**: Generate a summary at any point in the conversation whenever the agent chooses the copilot. **Summarize the conversation**.
         
 
-![enable features]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/6cde828d-aa37-4f33-b4c2-6a3093bd2fe5.png)
+![enable features](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/6cde828d-aa37-4f33-b4c2-6a3093bd2fe5.png)
 
 *Figure: enable features*
 
@@ -107,13 +107,13 @@ Perform the [Display case summary steps on custom case forms](https://learn.micr
 
 When you sign in to any of the Customer Service agent apps, copilot becomes activated on the right pane with the **Ask a Question** tab in focus. Copilot acts as your partner that can help answer questions without you having to search knowledge sources or other articles for information.
 
-![]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/22c3ac5c-dfe0-4ee7-841e-922387ad7916.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/22c3ac5c-dfe0-4ee7-841e-922387ad7916.png)
 
 You can ask free-form questions as you would ask a colleague or supervisor who might know the answers.
 
-![]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/f65688f6-dd80-44eb-adad-b6177ddcb41e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/f65688f6-dd80-44eb-adad-b6177ddcb41e.png)
 
-![]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/77edf9f2-f6c8-4aa1-b4bd-63f4c1049988.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/77edf9f2-f6c8-4aa1-b4bd-63f4c1049988.png)
 
 With copilot, you can perform the following actions:
 
@@ -143,7 +143,7 @@ Based on the triggers enabled by your administrator, the Copilot conversation su
     
 * When you select "Summarize conversation" on the ongoing dialog.
     
-* ![Summary]({{site.baseurl}}/images/clk3of002000p0al1gam0awij.md/b4b44b06-88b1-4c51-9721-199d3fc23771.png)
+* ![Summary](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clk3of002000p0al1gam0awij.md/b4b44b06-88b1-4c51-9721-199d3fc23771.png)
     
 
 *Figure: Summary*

--- a/holgerimbery/_posts/2023-07-22-enhancing-customer-support-with-power-virtual-agent-copilot.md
+++ b/holgerimbery/_posts/2023-07-22-enhancing-customer-support-with-power-virtual-agent-copilot.md
@@ -39,7 +39,7 @@ Select "Create with Copilot" when creating a new topic and let the AI generate i
 
 1. Open your bot and select **Topics**. On the **Topics** page, select **\+ New topic** and then **Create with Copilot**.
     
-    ![create with copilot]({{site.baseurl}}/images/clkdotw4c000h09jvdpjfasuy.md/57ad6438-b8a6-4c35-b84f-6b363c91ec36.png)
+    ![create with copilot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clkdotw4c000h09jvdpjfasuy.md/57ad6438-b8a6-4c35-b84f-6b363c91ec36.png)
     
     *Figure: create with Copilot*
     
@@ -47,7 +47,7 @@ Select "Create with Copilot" when creating a new topic and let the AI generate i
     
 3. In the **Create a topic to...** field, describe the topic you want to create in simple, plain English. You can include questions you want the bot to ask, messages it should show, and details of the specific behavior you want the bot to take.
     
-    ![action pane]({{site.baseurl}}/images/clkdotw4c000h09jvdpjfasuy.md/80f54d3a-048b-4388-857a-8aa777676ce3.png)
+    ![action pane](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clkdotw4c000h09jvdpjfasuy.md/80f54d3a-048b-4388-857a-8aa777676ce3.png)
     
     *Figure: "Create with copilot action" pane*
     
@@ -56,7 +56,7 @@ Select "Create with Copilot" when creating a new topic and let the AI generate i
 
 Based on your request, the authoring canvas will generate and open a new topic with trigger phrases and one or more nodes.
 
-![result]({{site.baseurl}}/images/clkdotw4c000h09jvdpjfasuy.md/c17c08d1-9d4a-463b-ab43-c99386855bb6.png)
+![result](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clkdotw4c000h09jvdpjfasuy.md/c17c08d1-9d4a-463b-ab43-c99386855bb6.png)
 
 *Figure: Result*
 
@@ -68,7 +68,7 @@ You can utilize AI to modify any topic within your bot. The topic doesn't need t
 
 Open your bot and select **Topics**. Select the topic you want to modify, then **Edit with the Copilot icon** on the menu bar just above the topic's conversation path.
 
-![Edit with Copilot]({{site.baseurl}}/images/clkdotw4c000h09jvdpjfasuy.md/992df61c-5c4b-4743-82bc-f715948054ce.png)
+![Edit with Copilot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clkdotw4c000h09jvdpjfasuy.md/992df61c-5c4b-4743-82bc-f715948054ce.png)
 
 *Figure: Edit with Copilot*  
 You can always view your most recent request to Copilot under the "What you asked for" label.

--- a/holgerimbery/_posts/2023-07-29-generative-answers-with-power-virtual-agents.md
+++ b/holgerimbery/_posts/2023-07-29-generative-answers-with-power-virtual-agents.md
@@ -29,7 +29,7 @@ In the next article of this series, I will explain how this feature is utilized 
 * enter a publicly available source into the URL field at the bottom
     
 
-![configure generative answers while generating a new bot]({{site.baseurl}}/images/clknobi76000909ldh0067s3b.md/c7be102f-65ed-43d2-a861-781310cc83c0.png)
+![configure generative answers while generating a new bot](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clknobi76000909ldh0067s3b.md/c7be102f-65ed-43d2-a861-781310cc83c0.png)
 
 Benefits of doing so:
 
@@ -50,11 +50,11 @@ It is always a got habit to start exploring new features as soon as they arise o
 
 To try out the feature, you can use a [demo page](https://aka.ms/pvademo) from Microsoft and your data.
 
-![demo page for generative answers]({{site.baseurl}}/images/clknobi76000909ldh0067s3b.md/b23b42bd-6f8c-4681-8854-9d61574e9f53.png)
+![demo page for generative answers](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clknobi76000909ldh0067s3b.md/b23b42bd-6f8c-4681-8854-9d61574e9f53.png)
 
 ## Tailor the experience if your tenant is enabled
 
-![configuration of additional resources]({{site.baseurl}}/images/clknobi76000909ldh0067s3b.md/62702f24-ef68-4228-832e-dc7c87bbcba2.png)
+![configuration of additional resources](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clknobi76000909ldh0067s3b.md/62702f24-ef68-4228-832e-dc7c87bbcba2.png)
 
 To add additional sources, go to the settings and add them.  
 The feature works with up to 2 sublevels.

--- a/holgerimbery/_posts/2023-08-12-elevate-your-dynamics-365-customer-service-with-the-voice-channel-a-simple-guide.md
+++ b/holgerimbery/_posts/2023-08-12-elevate-your-dynamics-365-customer-service-with-the-voice-channel-a-simple-guide.md
@@ -62,15 +62,15 @@ Connect your carrier via direct routing
 * Open the dialogue "add domain" to add the Carrier / SBC Domain to the configuration and to verify it.
     
 
-![]({{site.baseurl}}/images/cll7si5s4000m0aiiasahdhnq.md/523046d8-6ad1-41a8-9dcd-fbee2301b8f8.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cll7si5s4000m0aiiasahdhnq.md/523046d8-6ad1-41a8-9dcd-fbee2301b8f8.png)
 
 When verified, go to the "Session Border Controllers" Tab
 
-![]({{site.baseurl}}/images/cll7si5s4000m0aiiasahdhnq.md/72317cb2-ebda-4441-8f0e-32a3dc10e58a.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cll7si5s4000m0aiiasahdhnq.md/72317cb2-ebda-4441-8f0e-32a3dc10e58a.png)
 
 and add your carrier's SBCs
 
-![]({{site.baseurl}}/images/cll7si5s4000m0aiiasahdhnq.md/b57b8e77-6a3f-46b2-97db-d86606d4b8a6.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cll7si5s4000m0aiiasahdhnq.md/b57b8e77-6a3f-46b2-97db-d86606d4b8a6.png)
 
 Configure your Voice Routes according to your needs.
 

--- a/holgerimbery/_posts/2023-08-27-azure-openai-services-working-with-your-own-data-without-compromising-your-intellectual-property.md
+++ b/holgerimbery/_posts/2023-08-27-azure-openai-services-working-with-your-own-data-without-compromising-your-intellectual-property.md
@@ -61,23 +61,23 @@ go to: your "Azure OpenAI Studio", jump into your "playground"
 
 Select "Chat" and "add your data"
 
-![]({{site.baseurl}}/images/cllt3vjv5000g09mnfrj04ucn.md/963096dd-dd36-426e-9ea1-401bb5db7f81.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cllt3vjv5000g09mnfrj04ucn.md/963096dd-dd36-426e-9ea1-401bb5db7f81.png)
 
 You can then add data. Your data will be stored securely in your Azure Subscription.
 
-![]({{site.baseurl}}/images/cllt3vjv5000g09mnfrj04ucn.md/a44862b9-7396-497e-a8ec-e7e46dc18ea2.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cllt3vjv5000g09mnfrj04ucn.md/a44862b9-7396-497e-a8ec-e7e46dc18ea2.png)
 
 ## How Do I Connect a Power Virtual Agent?
 
 To connect a Power Virtual Agent bot to your data, choose the Deploy option. The bot will be created and automatically linked to your Azure resource.
 
-![]({{site.baseurl}}/images/cllt3vjv5000g09mnfrj04ucn.md/69f392fb-29d4-491e-b391-c36a21087649.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cllt3vjv5000g09mnfrj04ucn.md/69f392fb-29d4-491e-b391-c36a21087649.png)
 
-![]({{site.baseurl}}/images/cllt3vjv5000g09mnfrj04ucn.md/d3b3f08d-ef85-4b03-b7d6-83448ec9cc70.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cllt3vjv5000g09mnfrj04ucn.md/d3b3f08d-ef85-4b03-b7d6-83448ec9cc70.png)
 
 The "Conversational Boosting" system topic is automatically generated when the bot is created using Azure OpenAI Studio.
 
-![]({{site.baseurl}}/images/cllt3vjv5000g09mnfrj04ucn.md/0fd2bbab-26e5-495a-97dd-eb15a8706d47.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cllt3vjv5000g09mnfrj04ucn.md/0fd2bbab-26e5-495a-97dd-eb15a8706d47.png)
 
 In the Power Virtual Agents editing canvas, open the Data Source Configuration panel for your topic's "Generative Answers" node:
 
@@ -85,11 +85,11 @@ Open the Properties panel for the "Create Generative Answers" node and select Da
 
 On the Create Generative Answers node, select Edit under Data Sources.
 
-![]({{site.baseurl}}/images/cllt3vjv5000g09mnfrj04ucn.md/cb13d8b1-0970-416f-a5bf-de234fdabce1.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cllt3vjv5000g09mnfrj04ucn.md/cb13d8b1-0970-416f-a5bf-de234fdabce1.png)
 
 Edit the connection to the Azure OpenAI Service.
 
-![]({{site.baseurl}}/images/cllt3vjv5000g09mnfrj04ucn.md/24979867-c793-4e9e-8a90-f6ae6e975036.png"left")
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cllt3vjv5000g09mnfrj04ucn.md/24979867-c793-4e9e-8a90-f6ae6e975036.png"left")
 
 Once you have finished entering sources, close the menu. Be sure to save any changes made to your topic.
 

--- a/holgerimbery/_posts/2023-09-03-azure-openai-services-as-a-copilot-in-visual-studio-code.md
+++ b/holgerimbery/_posts/2023-09-03-azure-openai-services-as-a-copilot-in-visual-studio-code.md
@@ -35,18 +35,18 @@ To gain insights on Azure OpenAI service, please refer to [another article](http
 
 * Go to "https://oai.azure.com" and create a new model deployment if you have done this before
     
-    ![]({{site.baseurl}}/images/clm3fdxp2000709mlh5kjaxlq.md/efbb5214-a79c-4ed5-8e27-c13fad67e396.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clm3fdxp2000709mlh5kjaxlq.md/efbb5214-a79c-4ed5-8e27-c13fad67e396.png)
     
 * Select "gpt-35-turbo" and give your deployment a name.
     
 * Go to playground/completions/view code,
     
-    ![]({{site.baseurl}}/images/clm3fdxp2000709mlh5kjaxlq.md/bfcadc20-b099-491e-876e-93e00cafd8e3.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clm3fdxp2000709mlh5kjaxlq.md/bfcadc20-b099-491e-876e-93e00cafd8e3.png)
     
 * obtain the endpoint address (red) & API key (yellow), and store it in a safe place.
     
 
-![]({{site.baseurl}}/images/clm3fdxp2000709mlh5kjaxlq.md/cccd573f-9f53-4255-b05f-313cf815e52f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clm3fdxp2000709mlh5kjaxlq.md/cccd573f-9f53-4255-b05f-313cf815e52f.png)
 
 ## Add an extension to your Visual Studio Code.
 
@@ -54,7 +54,7 @@ In this article, I will use an exceptional extension created by [Andrew Butson](
 
 To install the extension, search for "AndrewButson.vscode-openai" in your Visual Studio Code and activate the Azure OpenAI Services as a resource provider. You can do this through the command palette by pressing "Ctrl+Shift+P" and entering "vscode-openai: Register openai service".
 
-![]({{site.baseurl}}/images/clm3fdxp2000709mlh5kjaxlq.md/0c34d87b-4d0c-438d-9728-bf5c762822b1.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clm3fdxp2000709mlh5kjaxlq.md/0c34d87b-4d0c-438d-9728-bf5c762822b1.png)
 
 * select openai.azure.com
     
@@ -71,11 +71,11 @@ To gain further insight into the model, please look at [another article of mine]
 
 Example 1: Working with Text
 
-![]({{site.baseurl}}/images/clm3fdxp2000709mlh5kjaxlq.md/66eab756-6e05-48cf-987b-590faba27a57.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clm3fdxp2000709mlh5kjaxlq.md/66eab756-6e05-48cf-987b-590faba27a57.png)
 
 Example 2: Working with Your Own Data - Utilizing Locally Accessible Data
 
-![]({{site.baseurl}}/images/clm3fdxp2000709mlh5kjaxlq.md/f826d1fc-ca84-412b-b3f9-6842f57f58c0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clm3fdxp2000709mlh5kjaxlq.md/f826d1fc-ca84-412b-b3f9-6842f57f58c0.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2023-09-10-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-1-a-simple-web-chat-experience-targeting-chatgpt-through-aoai.md
+++ b/holgerimbery/_posts/2023-09-10-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-1-a-simple-web-chat-experience-targeting-chatgpt-through-aoai.md
@@ -38,7 +38,7 @@ Microsoft fully controls the Azure OpenAI Service; Microsoft hosts the OpenAI mo
 
 With some experience in PowerShell and Azure Administration, you will get an interface like the one in the picture below. If you are familiar with Node.js, Python, and Azure CLI, you can take it a step further.
 
-![]({{site.baseurl}}/images/clmd6745i000609ig0gc44rwn.md/8f09852f-a24b-4a4c-9f1d-bf8790805662.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmd6745i000609ig0gc44rwn.md/8f09852f-a24b-4a4c-9f1d-bf8790805662.png)
 
 Within the following weeks, this series will guide you in utilizing Azure OpenAI Services to create your own company's "chatGPT" with all the necessary components to enhance your business without compromising it.
 
@@ -100,7 +100,7 @@ AZURE_OPENAI_MODEL_NAME= # the type you deployed
 We will find the details in the "playground", unter "Completions", and "View Code".  
 Where to find them is marked in the screenshot below with different colors.
 
-![]({{site.baseurl}}/images/clmd6745i000609ig0gc44rwn.md/5c35bf49-3acd-4ed2-9260-fe4c54ec5e2b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmd6745i000609ig0gc44rwn.md/5c35bf49-3acd-4ed2-9260-fe4c54ec5e2b.png)
 
 ## Create the Chat Interface and deploy it to an Azure App Service
 
@@ -152,7 +152,7 @@ Use the same command to update the app later
     * Go to Configurations, and add the "AZURE\_OPENAI\_\*" Settings using the details we saved before and the defaults from the ".env" file.
         
 
-![]({{site.baseurl}}/images/clmd6745i000609ig0gc44rwn.md/ce2e66e0-2cbe-45e8-be1e-5c95ef861c4c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmd6745i000609ig0gc44rwn.md/ce2e66e0-2cbe-45e8-be1e-5c95ef861c4c.png)
 
 * Restart the web app.
     
@@ -161,7 +161,7 @@ Use the same command to update the app later
     * Go to "Settings", Authentication" in the web app and add, e.g., Microsoft with the defaults as an identity provider.
         
     
-    ![]({{site.baseurl}}/images/clmd6745i000609ig0gc44rwn.md/a926f363-e560-4ee8-8d59-2a20f6b0931e.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmd6745i000609ig0gc44rwn.md/a926f363-e560-4ee8-8d59-2a20f6b0931e.png)
     
 
 Go to https://{app-name}.azurewebsites.net and find your first version of your "ownGPT" secured with an identity provider and in a safe environment.

--- a/holgerimbery/_posts/2023-09-16-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-2-incorporating-your-own-data-to-create-unique-experiences.md
+++ b/holgerimbery/_posts/2023-09-16-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-2-incorporating-your-own-data-to-create-unique-experiences.md
@@ -32,7 +32,7 @@ In this second part of the series, we will learn how to customize our chatGPT cl
 * Click on "Add a data source"
     
 
-![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/308a5f73-92f1-45da-8253-c8ecb5d52359.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/308a5f73-92f1-45da-8253-c8ecb5d52359.png)
 
 * Choose "Upload files" and follow the wizard to create an "Azure Blob Storage," an "Azure Cognitive Search Resource" with the ARM templates of the wizard.
     
@@ -43,21 +43,21 @@ In this second part of the series, we will learn how to customize our chatGPT cl
 * After acknowledging the information, click "Next."
     
 
-![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/203241fb-4b76-4bc0-9654-3befe85bf843.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/203241fb-4b76-4bc0-9654-3befe85bf843.png)
 
 * Next, upload some test data to the blob storage to test the installation.
     
 
-![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/77cad8c9-a308-45bc-b788-be3c92789279.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/77cad8c9-a308-45bc-b788-be3c92789279.png)
 
 * After finishing the upload, everything will be created in the background, and the Assistant setup tells you to wait some minutes
     
 
-![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/c763d8e1-5f90-4f30-b240-b3c530b8759c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/c763d8e1-5f90-4f30-b240-b3c530b8759c.png)
 
 Once the wizard has completed its task, you'll see the created resource in the status window beneath the wizard. You can then restrict the response to your data and verify its functionality with a brief chat session.
 
-![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/3668284a-a164-4434-86a2-5c8764cc540c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/3668284a-a164-4434-86a2-5c8764cc540c.png)
 
 ## Add the resources to the ownGPT web interface
 
@@ -65,7 +65,7 @@ Once the wizard has completed its task, you'll see the created resource in the s
 
 Update your .env file and add the following details:
 
-![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/c1db43d6-d73a-460a-9390-5f8bd395baeb.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/c1db43d6-d73a-460a-9390-5f8bd395baeb.png)
 
 restart your ownGPT by executing ./start.cmd
 
@@ -73,18 +73,18 @@ and try it in your browser at https://127.0.0.1:5000
 
 The result should look similar to the picture below
 
-![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/65b185bd-6f5f-428c-94f4-dbfab681f2be.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/65b185bd-6f5f-428c-94f4-dbfab681f2be.png)
 
 ### Update the config of the Web App
 
 * go to Settings / Applications, and add the "AZURE\_Search\*" elements from before as application settings. Do not forget to restart the web app.
     
 
-![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/39ebdf1a-14f4-432b-88e0-6daf841156a1.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/39ebdf1a-14f4-432b-88e0-6daf841156a1.png)
 
 * Test the web app in a private browser and see that your identity provider kicks in.
     
-    ![]({{site.baseurl}}/images/clmllxvzo000009ml4w203zmh.md/eb4f0ec0-2e43-4c94-bcec-c91e2d795fa5.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmllxvzo000009ml4w203zmh.md/eb4f0ec0-2e43-4c94-bcec-c91e2d795fa5.png)
     
 * The test in the web chat should then give you the same result as testing the chat interface locally.
     

--- a/holgerimbery/_posts/2023-09-22-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-3-activate-chat-history-for-adding-a-more-convenient-way-to-work.md
+++ b/holgerimbery/_posts/2023-09-22-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-3-activate-chat-history-for-adding-a-more-convenient-way-to-work.md
@@ -34,7 +34,7 @@ To enable chat history, deploy your model as a temporary web app.
     "Enable chat history".
     
 
-![]({{site.baseurl}}/images/clmv2ynko00050akzaxz551wp.md/69ca9eeb-a14b-461e-8bd3-e802692e4f59.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmv2ynko00050akzaxz551wp.md/69ca9eeb-a14b-461e-8bd3-e802692e4f59.png)
 
 After deploying the web app, we open it in the Azure portal and copy the content of the Application Settings (found in the Settings configurations) related to AZURE\_COSMOSDB\* as well as the API of the COSMOSDB itself.
 
@@ -53,13 +53,13 @@ AZURE_COSMOSDB_ACCOUNT_KEY=******************
 
 and restart the bot; the result on HTTP://127.0.0.1:5000 should look similar to the screenshot below.
 
-![]({{site.baseurl}}/images/clmv2ynko00050akzaxz551wp.md/a20d5993-36de-44ad-a109-daebacd398ec.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmv2ynko00050akzaxz551wp.md/a20d5993-36de-44ad-a109-daebacd398ec.png)
 
 Deploy it to your web app on Azure.
 
 After selecting the Web App in the Azure portal, navigate to Settings / Configuration and add the appropriate Application Settings there.
 
-![]({{site.baseurl}}/images/clmv2ynko00050akzaxz551wp.md/1a6da2e1-fcda-45e5-9324-9874a085b0c9.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clmv2ynko00050akzaxz551wp.md/1a6da2e1-fcda-45e5-9324-9874a085b0c9.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2023-09-30-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-4-adding-additional-channels-and-take-action-on-your-data.md
+++ b/holgerimbery/_posts/2023-09-30-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-4-adding-additional-channels-and-take-action-on-your-data.md
@@ -37,21 +37,21 @@ In the same way, we added data to our "ownGPT" we will create the link to a new 
 * Choose "Chat" in the "Playground" and "Add own Data" utilizing the resources we already created in the step before (part 2 of this series)
     
 
-![]({{site.baseurl}}/images/cln5owko6000l08lg21efg745.md/a9eb6b03-da9a-4bd5-9d4f-5e30d946b72c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cln5owko6000l08lg21efg745.md/a9eb6b03-da9a-4bd5-9d4f-5e30d946b72c.png)
 
-![]({{site.baseurl}}/images/cln5owko6000l08lg21efg745.md/70918b21-a834-4e07-84e9-8c5fb50fcfab.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cln5owko6000l08lg21efg745.md/70918b21-a834-4e07-84e9-8c5fb50fcfab.png)
 
-![]({{site.baseurl}}/images/cln5owko6000l08lg21efg745.md/af25c2fe-82ed-4fc3-97e1-b15b810227e2.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cln5owko6000l08lg21efg745.md/af25c2fe-82ed-4fc3-97e1-b15b810227e2.png)
 
 * and then we click on "Deploy to" and choose "A new Power Virtual Agent bot"
     
 
-![]({{site.baseurl}}/images/cln5owko6000l08lg21efg745.md/75338bc6-5b68-498a-9857-8fdf8105b389.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cln5owko6000l08lg21efg745.md/75338bc6-5b68-498a-9857-8fdf8105b389.png)
 
 * We give our consent by clicking "Continue in Power Virtual Agents"
     
 
-![]({{site.baseurl}}/images/cln5owko6000l08lg21efg745.md/5f6de7d7-ed89-41fe-a11d-11ff9dc50330.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cln5owko6000l08lg21efg745.md/5f6de7d7-ed89-41fe-a11d-11ff9dc50330.png)
 
 > Note
 > 
@@ -61,7 +61,7 @@ In the same way, we added data to our "ownGPT" we will create the link to a new 
 
 A conversational boosting system topic is automatically generated when the bot is created using Azure OpenAI Studio.
 
-![]({{site.baseurl}}/images/cln5owko6000l08lg21efg745.md/d0640205-1ca7-4cb7-b037-6b1640d73201.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cln5owko6000l08lg21efg745.md/d0640205-1ca7-4cb7-b037-6b1640d73201.png)
 
 In Power Virtual Agents, open the Data Source Configuration panel for your topic's generative answers node:
 
@@ -69,11 +69,11 @@ Open the Properties panel for the Create Generative Answers node and select Data
 
 On the Create Generative Answers node, select Edit under Data Sources.
 
-![]({{site.baseurl}}/images/cln5owko6000l08lg21efg745.md/3d51dbb1-4e88-4aae-908c-ebc1ce1c378d.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cln5owko6000l08lg21efg745.md/3d51dbb1-4e88-4aae-908c-ebc1ce1c378d.png)
 
 Edit the connection to the Azure OpenAI Service.
 
-![]({{site.baseurl}}/images/cln5owko6000l08lg21efg745.md/45d9053e-7dfe-445f-826b-ca3f160c309c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cln5owko6000l08lg21efg745.md/45d9053e-7dfe-445f-826b-ca3f160c309c.png)
 
 Once you have finished entering sources, close the menu. Be sure to save any changes made to your topic.
 

--- a/holgerimbery/_posts/2023-10-14-revolutionizing-bot-building-unleash-the-power-of-generative-actions-in-power-virtual-agents.md
+++ b/holgerimbery/_posts/2023-10-14-revolutionizing-bot-building-unleash-the-power-of-generative-actions-in-power-virtual-agents.md
@@ -39,19 +39,19 @@ Between answering user questions by chatting over proprietary company informatio
 * Open your bot and select "Topics." On the Topics page, click the "+Add" button, and then choose "Plugin action (preview)."
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/759f7083-264a-4e93-a9d9-fe450712d124.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/759f7083-264a-4e93-a9d9-fe450712d124.png)
 
 * In the "Add an action (preview)" wizard now open, you can search for the plugin action you want to use within your bot.  
     Upon opening the wizard, the default list includes "Power Automate Flows" and "custom connectors" available in the environment, commonly used pre-built connectors, and Bot Framework Skills that have been registered with your bot.
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/c308cc41-c4a0-43d2-8824-3240cc04b364.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/c308cc41-c4a0-43d2-8824-3240cc04b364.png)
 
 * Select the action you want to use.  
     You will proceed to the wizard's next step to configure the action's connection. Once your connection has been successfully configured, click "Next."
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/87ad8e5d-5247-4b63-ab0c-a1837739967e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/87ad8e5d-5247-4b63-ab0c-a1837739967e.png)
 
 * Configure the display name and Description for your plugin action.  
     Typically, these are pre-populated based on the action you selected. On this page, you can decide whether you want your users to confirm the information they have provided before the plugin action is executed. This can often be helpful, particularly for actions that modify a user's data, such as inserting or updating a record in a table.
@@ -64,7 +64,7 @@ Between answering user questions by chatting over proprietary company informatio
 * Once you have configured your name, Description, and confirmation options, click "Next."
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/56641ad3-9ba3-4b9e-b4dc-a16dfdfe125e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/56641ad3-9ba3-4b9e-b4dc-a16dfdfe125e.png)
 
 * For each input on your action, you can now configure the **Display name** and **Description**.
     
@@ -73,7 +73,7 @@ Between answering user questions by chatting over proprietary company informatio
 * The Description of the input can impact the generated question. Additionally, you can modify the "Identify as" option to a specific entity type based on the input being gathered.
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/c213b6d3-b944-4267-8584-91978b4a121e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/c213b6d3-b944-4267-8584-91978b4a121e.png)
 
 * Once you have configured your inputs, click "Next."
     
@@ -84,7 +84,7 @@ Between answering user questions by chatting over proprietary company informatio
 * To add an output, click "Add" and then choose from the available outputs, which are determined by the action you selected at the beginning of the wizard.
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/cab3afa5-4c2c-4088-a9ba-8651941fa02b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/cab3afa5-4c2c-4088-a9ba-8651941fa02b.png)
 
 * In addition to determining which variables are populated by your plugin action, you can also have your plugin action send a response back to the user once the action has been executed.
     
@@ -93,7 +93,7 @@ Between answering user questions by chatting over proprietary company informatio
 * Similar to the confirmation editor, you can insert references to output variables from the action using Power Fx, such as the `Topic.Output.responses.daily.tempLo` or `Topic.Output.responses.daily.tempHi` variable shown in this example.
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/f8ef4e48-6669-4236-85f3-d598ecdbcb7b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/f8ef4e48-6669-4236-85f3-d598ecdbcb7b.png)
 
 * Select Next to proceed to the final step in the wizard, where you can review your plugin action configuration. You can also go back to make changes.
     
@@ -102,7 +102,7 @@ Between answering user questions by chatting over proprietary company informatio
 * Once added, your plugin can be viewed in the Plugin Actions (preview) tab on the Topics page.
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/52549cf6-8d54-4531-b5dd-e33ab6684bc3.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/52549cf6-8d54-4531-b5dd-e33ab6684bc3.png)
 
 ### **Call a plugin action.**
 
@@ -122,14 +122,14 @@ To call a plugin action, explicitly invoke it from within a topic, just as you w
     ```
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/805c54e9-a7f0-4cd2-861e-f897de69cea1.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/805c54e9-a7f0-4cd2-861e-f897de69cea1.png)
 
 * Select "Add node (+)" and then choose "Call an action".
     
 * Navigate to the "Plugin actions (preview)" tab and select the plugin action you previously created, "Get forecast for today".
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/07e51959-4032-48a2-b5d1-222f72e31e1c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/07e51959-4032-48a2-b5d1-222f72e31e1c.png)
 
 * Save your work
     
@@ -143,13 +143,13 @@ To call a plugin action, explicitly invoke it from within a topic, just as you w
 * Now that this input has been overridden, the bot won't ask the user for a value.
     
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/c224a0c7-8db1-4cff-8d19-ab6d4849aeaf.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/c224a0c7-8db1-4cff-8d19-ab6d4849aeaf.png)
 
 ### **Test your plugin action.**
 
 Once you've added a plugin action to a topic, you can test it and see an output similar to the one displayed below.
 
-![]({{site.baseurl}}/images/clnpzjx4j000009kzfhwda2l2.md/3606a40d-a958-40fd-a75a-eb27aafcb7ef.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clnpzjx4j000009kzfhwda2l2.md/3606a40d-a958-40fd-a75a-eb27aafcb7ef.png)
 
 GPT-driven conversations are more fluid than traditional, pre-written questions, enabling users to answer multiple questions in a single turn or modify previously entered values.
 

--- a/holgerimbery/_posts/2023-10-28-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-2-environment-setup.md
+++ b/holgerimbery/_posts/2023-10-28-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-2-environment-setup.md
@@ -66,7 +66,7 @@ Developer environments are extremely useful for testing features or simply devel
   
 * Click on "New" in the top navigation.
   
-    ![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/8334aca2-bfa4-4b60-a3a9-b8d09afdef4b.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/8334aca2-bfa4-4b60-a3a9-b8d09afdef4b.png)
     
 * When the dialog window appears on the right-hand side, enter the following information:
   
@@ -80,7 +80,7 @@ Developer environments are extremely useful for testing features or simply devel
     
 * Select "yes" to add dataverse data store, and select "Next" and "Save"
   
-* ![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/c311fd78-5951-40d9-8dde-fd559ed32bd0.png)
+* ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/c311fd78-5951-40d9-8dde-fd559ed32bd0.png)
   
     repeat the same for a `test (test)` and for a `production (prod)` environment
     
@@ -109,7 +109,7 @@ Developer environments are extremely useful for testing features or simply devel
 * Create a new repository with a meaningful name
   
 
-![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/f935f66d-4b8b-48b2-bea7-43c2005c6ff6.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/f935f66d-4b8b-48b2-bea7-43c2005c6ff6.png)
 
 ### Creating a codespace
 
@@ -117,13 +117,13 @@ A codespace is a cloud-hosted development environment accessible from anywhere. 
 
 * Navigate to your newly created repository, locate the &lt;&gt; Code button, and click on it.
   
-    ![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/26b68c01-7ab5-4c5a-9c75-69755151b42f.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/26b68c01-7ab5-4c5a-9c75-69755151b42f.png)
     
 * In the Code pop-up, select the "Codespaces" tab.
   
 * Click on "Create codespace on the main".
   
-    ![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/696b5235-6136-4509-a2e9-678285b5ad6a.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/696b5235-6136-4509-a2e9-678285b5ad6a.png)
     
 
 A codespace will be created for you in a new tab. This process might take a few seconds. Upon completion, you will have a fully functional Visual Studio Code environment within your browser.
@@ -139,7 +139,7 @@ To work with your solution and save it to the repository, you need to install th
 * Click "Install."
   
 
-![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/1e6cf384-be58-4b9d-a9e7-6dc5b170de83.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/1e6cf384-be58-4b9d-a9e7-6dc5b170de83.png)
 
 ### Connecting to the Power Platform environment
 
@@ -149,7 +149,7 @@ To work with your solution and save it to the repository, you need to install th
   
 * You will notice that it says, "No auth profiles found on this computer." We will create one.
   
-    ![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/78825e39-69f8-4db6-97ca-7a353b5e41c7.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/78825e39-69f8-4db6-97ca-7a353b5e41c7.png)
     
 * Click on the hamburger menu icon in the top left corner, then hover over "Terminal" and click "New Terminal."
   
@@ -163,11 +163,11 @@ To work with your solution and save it to the repository, you need to install th
     
 * You will be prompted to use a web browser for authentication. Copy (Ctrl + C) the code provided in the terminal, and then Ctrl + click on the link also provided in the terminal.
   
-    ![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/f64885c2-5e71-4dba-af44-b9738220a9f0.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/f64885c2-5e71-4dba-af44-b9738220a9f0.png)
     
 * Once you click on the link, a new browser tab will open. Paste the code into the browser and click "Next."
   
-    ![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/f6e9546e-f18e-446e-b7c2-9fc3b48c90e1.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/f6e9546e-f18e-446e-b7c2-9fc3b48c90e1.png)
     
 * Sign in. Click "Continue."
   
@@ -175,7 +175,7 @@ To work with your solution and save it to the repository, you need to install th
   
 * Refresh the Auth Profiles section by clicking the "Refresh" button next to "Auth Profiles."
   
-* ![]({{site.baseurl}}/images/clo9zpucx000709l67t48cywk.md/57624b10-cd54-4296-b83d-2b7c6b9cce4f.png)
+* ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clo9zpucx000709l67t48cywk.md/57624b10-cd54-4296-b83d-2b7c6b9cce4f.png)
   
     After completing these steps, you should see your Authentication Profile and your Environments, allowing you to work with your environments effectively.
     

--- a/holgerimbery/_posts/2023-11-04-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-3-working-with-solutions.md
+++ b/holgerimbery/_posts/2023-11-04-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-3-working-with-solutions.md
@@ -42,22 +42,22 @@ Create a new solution
   
 * Choose "solutions" and then "+new Solution"
   
-    ![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/d9fe797b-cdf7-4a22-b962-5d8c4787fff0.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/d9fe797b-cdf7-4a22-b962-5d8c4787fff0.png)
     
     * give it a meaningful full name and hit "create"
       
     
-    ![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/a312904c-5724-4054-b3d6-a6ef83f4e599.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/a312904c-5724-4054-b3d6-a6ef83f4e599.png)
     
     * Open the new solution and add all components associated with the project.
       
     
-    ![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/b0a64905-bd05-4942-bcb9-a547c8b1f672.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/b0a64905-bd05-4942-bcb9-a547c8b1f672.png)
     
 
 (in this case, we have created a solution with a basic Power Virtual Agents bot)
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/00f90c2b-135e-4846-8d21-d4a335178a0f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/00f90c2b-135e-4846-8d21-d4a335178a0f.png)
 
 ## Initial export of the solution
 
@@ -79,7 +79,7 @@ pac org list
 pac org select --environment <Unique Name>
 ```
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/5f91126a-31a8-4a87-b2e3-2fbfcf3a5c30.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/5f91126a-31a8-4a87-b2e3-2fbfcf3a5c30.png)
 
 * list all your solutions within the environment
   
@@ -88,7 +88,7 @@ pac org select --environment <Unique Name>
 pac solution list
 ```
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/b03305fc-ebfe-46bf-a1f9-139acb9f579f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/b03305fc-ebfe-46bf-a1f9-139acb9f579f.png)
 
 * create a new path in your repository and export the solution you created in the step before
   
@@ -101,7 +101,7 @@ pac solution list
     ```
     
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/d5afec8d-0579-4471-840d-9c10f5cf20dc.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/d5afec8d-0579-4471-840d-9c10f5cf20dc.png)
 
 * unpack the solution
   
@@ -112,7 +112,7 @@ pac solution list
 * find a result similar to the screenshot in your codespace
   
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/f1cc8fda-74d1-4b93-8f99-3bc2d329b1ba.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/f1cc8fda-74d1-4b93-8f99-3bc2d329b1ba.png)
 
 * commit your code to the repository
   
@@ -121,11 +121,11 @@ pac solution list
     * enter a meaningful commit message, hit "commit" and sync
       
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/a18ca8d1-42ae-4fa9-9d41-1b9af3775caf.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/a18ca8d1-42ae-4fa9-9d41-1b9af3775caf.png)
 
 * Find your first commit in your repository on GitHub.
   
-    ![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/200c81c9-b9a3-4e88-80b5-56eaac6ff4c9.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/200c81c9-b9a3-4e88-80b5-56eaac6ff4c9.png)
     
 
 ## Create a new branch, export a change, and create a pull request
@@ -133,15 +133,15 @@ pac solution list
 After working on your solution, create a new branch in your codespace.  
 Do not forget to add your changes to the solution, e.g right click on your bot and select "advanced" and "+Add required objects"
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/c3020671-a43c-458c-85e4-f3eb6e573dbd.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/c3020671-a43c-458c-85e4-f3eb6e573dbd.png)
 
 * click on "main" in the status line
   
-    ![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/a6882926-e537-46f4-a208-8a12f285c91d.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/a6882926-e537-46f4-a208-8a12f285c91d.png)
     
 * click on "+ Create new branch"
   
-    ![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/96f9043a-1b22-426b-97fc-30ee696d7340.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/96f9043a-1b22-426b-97fc-30ee696d7340.png)
     
 * please give it a meaningful name and export your solution.
   
@@ -154,7 +154,7 @@ Do not forget to add your changes to the solution, e.g right click on your bot a
 * find your changes in the source control menu, give your commit a name, and commit
   
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/93abf473-02ee-4b09-b34a-c3092514eff9.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/93abf473-02ee-4b09-b34a-c3092514eff9.png)
 
 * create a new pull request via codespaces vscode web.
   
@@ -163,12 +163,12 @@ Do not forget to add your changes to the solution, e.g right click on your bot a
     * , click on the "Create Pull Request" icon
       
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/bc6657e6-6e48-4c01-bdcf-eef9a6f75906.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/bc6657e6-6e48-4c01-bdcf-eef9a6f75906.png)
 
 * Give your PR a meaningful name and describe it to assist the repository maintainer in deciding to merge the PR.
   
 
-![]({{site.baseurl}}/images/clojq50t5000109kyg03rhzr5.md/f632f621-263f-48b9-a837-471badc22abf.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clojq50t5000109kyg03rhzr5.md/f632f621-263f-48b9-a837-471badc22abf.png)
 
 * the maintainer will then see the PR and can decide whether to merge or not
   

--- a/holgerimbery/_posts/2023-11-11-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-4-working-with-pipelines.md
+++ b/holgerimbery/_posts/2023-11-11-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-4-working-with-pipelines.md
@@ -114,7 +114,7 @@ Deploy the pipeline solution in your production environment.
     
 * In the sidebar that appears, scroll down and select the "Power Platform Pipelines" app.
     
-    ![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/64b7364a-74b4-45ae-b784-7215fd9b7127.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/64b7364a-74b4-45ae-b784-7215fd9b7127.png)
     
 * Then, click the "Next" button at the bottom of the sidebar.
     
@@ -125,7 +125,7 @@ Deploy the pipeline solution in your production environment.
 
 You can refresh the page by clicking the Refresh button in the command bar at the top. Once completed, go to the [maker portal](https://make.powerapps.com/) and select the correct environment (Production). If everything went smoothly, you should see the Deployment Pipeline Configuration app in the Apps section of the maker portal.
 
-![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/bcdccc51-f945-4860-8cb3-b4011eee89ef.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/bcdccc51-f945-4860-8cb3-b4011eee89ef.png)
 
 ## Create a new Pipeline.
 
@@ -142,16 +142,16 @@ There is also a Pipeline Setup section to view your environments and pipelines.
 
 Lastly, a Deployments section allows you to view the run history and find solution artifacts.
 
-![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/7305db2f-ccd1-4873-8ea9-5f3260908288.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/7305db2f-ccd1-4873-8ea9-5f3260908288.png)
 
 create a new pipeline by selecting three dots and then the "+ New" button on the "Active Development Pipeline" Dashboard
 
-![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/84a14f6b-957f-478d-be28-5bc35ee49259.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/84a14f6b-957f-478d-be28-5bc35ee49259.png)
 
 create a new pipeline by selecting the new button on the `Pipelines Dashboard`.  
 The result should be similar to the screenshot below
 
-![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/4418a35a-ef19-4534-91cd-8d67238f745c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/4418a35a-ef19-4534-91cd-8d67238f745c.png)
 
 As you can see, there are two sections: Linked Development Environments and Deployment Stages.
 
@@ -167,17 +167,17 @@ The Deployment Stages section allows you to add stages following your developmen
 
 Add or create a development environment with the respecting buttons and find the result similar to the screenshot
 
-![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/6b6cc054-3743-4309-b4fb-7419f18fcb46.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/6b6cc054-3743-4309-b4fb-7419f18fcb46.png)
 
 ## Create stages
 
 Create your first stage, "deploy to test," via "+ New Deployment Stage."
 
-![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/7a122b09-c71f-4dab-b13c-400e57755a86.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/7a122b09-c71f-4dab-b13c-400e57755a86.png)
 
 the process is self-explanatory
 
-![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/0e0f58a9-0353-44b2-9162-57ef030cdd83.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/0e0f58a9-0353-44b2-9162-57ef030cdd83.png)
 
 Ensure you click the "New Deployment Stage" button again to add a second deployment stage called "Deploy to Prod". Follow a similar process as above, but select the Previous Deployment Stage and search for the "Deploy to Test" stage.
 
@@ -193,7 +193,7 @@ This two-stage process ensures the quality and reliability of the solutions deve
 
 Select your solution in your development environment and press the "rocket" symbol to fire up your pipeline.
 
-![]({{site.baseurl}}/images/clotvy78m000d09ju8kh29r6z.md/143b7f1f-a377-459a-b9f6-f79cc091bc32.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clotvy78m000d09ju8kh29r6z.md/143b7f1f-a377-459a-b9f6-f79cc091bc32.png)
 
 Similar to "deploy to prod"
 

--- a/holgerimbery/_posts/2023-11-18-multilingual-magic-power-virtual-agents-copilots-for-global-engagement-preview.md
+++ b/holgerimbery/_posts/2023-11-18-multilingual-magic-power-virtual-agents-copilots-for-global-engagement-preview.md
@@ -35,22 +35,22 @@ To implement a bot as a multilingual bot:
 * Click on Add Languages.
     
 
-![]({{site.baseurl}}/images/clp3vr11t000f08l9ai5p9xss.md/f645727c-bf0a-461e-adc1-a41a01cba4d1.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clp3vr11t000f08l9ai5p9xss.md/f645727c-bf0a-461e-adc1-a41a01cba4d1.png)
 
 * Select an additional language you wish to utilize.
     
 
-![]({{site.baseurl}}/images/clp3vr11t000f08l9ai5p9xss.md/455d3242-51fa-46ee-bb26-e982748683af.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clp3vr11t000f08l9ai5p9xss.md/455d3242-51fa-46ee-bb26-e982748683af.png)
 
 * Press "add languages"
     
 
-![]({{site.baseurl}}/images/clp3vr11t000f08l9ai5p9xss.md/dcef9c37-eee3-442a-bc8f-c6009b7cbc86.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clp3vr11t000f08l9ai5p9xss.md/dcef9c37-eee3-442a-bc8f-c6009b7cbc86.png)
 
 * download the language file after creation or after modification of your bot
     
 
-![]({{site.baseurl}}/images/clp3vr11t000f08l9ai5p9xss.md/54ef1971-6efa-438a-aea3-a08a62d94a2a.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clp3vr11t000f08l9ai5p9xss.md/54ef1971-6efa-438a-aea3-a08a62d94a2a.png)
 
 * You may want to use a translation tool to convert the .resx file or manually translate the strings.  
     One such tool you could use is, for example, [ResxTranslator](https://github.com/stevencohn/ResxTranslator)
@@ -58,12 +58,12 @@ To implement a bot as a multilingual bot:
 * Upload the translated content and proceed to work with your bot as usual.
     
 
-![]({{site.baseurl}}/images/clp3vr11t000f08l9ai5p9xss.md/32f9737f-2dc6-4bef-81a3-66f9b13798d9.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clp3vr11t000f08l9ai5p9xss.md/32f9737f-2dc6-4bef-81a3-66f9b13798d9.png)
 
 * Select the language on top of your "test chatbot" window to test your translated bot.
     
 
-![]({{site.baseurl}}/images/clp3vr11t000f08l9ai5p9xss.md/886dc4e7-a044-4645-a274-5f2e050cbb1f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clp3vr11t000f08l9ai5p9xss.md/886dc4e7-a044-4645-a274-5f2e050cbb1f.png)
 
 ## Next steps
 

--- a/holgerimbery/_posts/2023-11-25-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-5-approval-with-pipeline.md
+++ b/holgerimbery/_posts/2023-11-25-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-5-approval-with-pipeline.md
@@ -67,7 +67,7 @@ In this task, you will learn how to create an approval flow that will handle the
     
 * Configure the trigger inputs
     
-    ![]({{site.baseurl}}/images/clpdsc6fv000v08l8dut101a3.md/44261b65-2178-4210-b0a1-d43d7f0a74c7.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clpdsc6fv000v08l8dut101a3.md/44261b65-2178-4210-b0a1-d43d7f0a74c7.png)
     
 * Select the three dots in the top-right corner of the trigger, then choose "Settings" to open the trigger settings.
     
@@ -89,7 +89,7 @@ In this task, you will learn how to create an approval flow that will handle the
     
 * Press the "Done" button at the bottom of the trigger card to save the trigger conditions.
     
-    ![]({{site.baseurl}}/images/clpdsc6fv000v08l8dut101a3.md/f2f43595-1381-4e4f-9f01-7d0945deb499.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clpdsc6fv000v08l8dut101a3.md/f2f43595-1381-4e4f-9f01-7d0945deb499.png)
     
 * Click the "New step" button to add an action that initiates and awaits approval.
     
@@ -104,7 +104,7 @@ In this task, you will learn how to create an approval flow that will handle the
     * For "assigned to", enter the email address of your user.
         
     
-    ![]({{site.baseurl}}/images/clpdsc6fv000v08l8dut101a3.md/2f15a5aa-b09a-4c2b-8a26-70daa9e27414.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clpdsc6fv000v08l8dut101a3.md/2f15a5aa-b09a-4c2b-8a26-70daa9e27414.png)
     
     In production scenarios, an admin would typically approve deployments.
     
@@ -154,7 +154,7 @@ In this task, you will learn how to create an approval flow that will handle the
     
     Add the **ActionInputs StageRunId** dynamic content field from the **When an action is performed** trigger as StageRunId.
     
-    ![]({{site.baseurl}}/images/clpdsc6fv000v08l8dut101a3.md/f6484747-89e1-472b-bb5e-f46a2a0e7696.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clpdsc6fv000v08l8dut101a3.md/f6484747-89e1-472b-bb5e-f46a2a0e7696.png)
     
 * Save the flow
     
@@ -166,7 +166,7 @@ In this task, you will learn how to create an approval flow that will handle the
 * Open your emails and find the approval request.
     
 
-![]({{site.baseurl}}/images/clpdsc6fv000v08l8dut101a3.md/4f9b6ef8-4054-4884-8762-1b2538a7e2a5.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clpdsc6fv000v08l8dut101a3.md/4f9b6ef8-4054-4884-8762-1b2538a7e2a5.png)
 
 * Approve the request
     

--- a/holgerimbery/_posts/2023-12-09-sharepoint-integration-add-your-custom-microsoft-copilot-studio-copilot-with-sso-support.md
+++ b/holgerimbery/_posts/2023-12-09-sharepoint-integration-add-your-custom-microsoft-copilot-studio-copilot-with-sso-support.md
@@ -44,11 +44,11 @@ Please find a [detailed description](https://github.com/microsoft/CopilotStudioS
 
 After following all the steps,
 
-![]({{site.baseurl}}/images/clpxtbiod000m08kthtsa5bva.md/8d4eb243-dd07-406d-a659-34a3d2458ca4.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clpxtbiod000m08kthtsa5bva.md/8d4eb243-dd07-406d-a659-34a3d2458ca4.png)
 
 Press the button on the bottom and enjoy your bot on SharePoint
 
-![]({{site.baseurl}}/images/clpxtbiod000m08kthtsa5bva.md/d4051860-e09f-4792-abe9-d22478fd9b1a.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clpxtbiod000m08kthtsa5bva.md/d4051860-e09f-4792-abe9-d22478fd9b1a.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2023-12-16-dynamics-365-customer-service-verify-users-with-a-single-use-password-in-text-chat.md
+++ b/holgerimbery/_posts/2023-12-16-dynamics-365-customer-service-verify-users-with-a-single-use-password-in-text-chat.md
@@ -47,7 +47,7 @@ To start with the basics to identify the user, we implement a pre-conversation s
 In this example, we ask three questions.  
 The user´s name, the email address (for returning/registered customers), and the consent for our T&Cs.
 
-![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/e1c2067b-e4fa-4930-a595-dca894977ee8.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/e1c2067b-e4fa-4930-a595-dca894977ee8.png)
 
 ### Prerequisites
 
@@ -56,7 +56,7 @@ The user´s name, the email address (for returning/registered customers), and th
 * Add this flow to the "Conversation Start" topic with a question, asking the user. to authenticate.
     
 
-![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/41f3bb8d-bc59-4425-baf8-aa68908f095f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/41f3bb8d-bc59-4425-baf8-aa68908f095f.png)
 
 ### Authentication as a topic
 
@@ -66,34 +66,34 @@ The user´s name, the email address (for returning/registered customers), and th
     "generate the verification code"
     
 
-![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/dbc090a5-35db-4300-9c6d-c124118888fb.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/dbc090a5-35db-4300-9c6d-c124118888fb.png)
 
 * The generated code is the output of the flow and is stored in a variable. The flow itself sends the code to the user's registered email address.
     
 * Ask the user to input the code using a question node.
     
-    ![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/c8351c89-8719-4604-94e2-2bfc8f810fd9.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/c8351c89-8719-4604-94e2-2bfc8f810fd9.png)
     
     * Verify the code using another flow, "Validate the code."
         
 
-![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/8fbe48fe-ee9f-40ce-9707-59942328b1cb.png"left")
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/8fbe48fe-ee9f-40ce-9707-59942328b1cb.png"left")
 
 ### Flow 1: generate verification code
 
-![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/9b5fea2b-a471-4a40-9e3c-5ecb6bf8c327.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/9b5fea2b-a471-4a40-9e3c-5ecb6bf8c327.png)
 
 * Create the flow as shown above with `CodeLength`.
     
 
-![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/9eb3e1e2-4304-417f-9397-6753f7c9575f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/9eb3e1e2-4304-417f-9397-6753f7c9575f.png)
 
 * Use a formula like:
     
 
 `plaintext substring(replace(guid(), '-', ''), 0, min(variables('CodeLength'), 32))`to create the verification code.
 
-![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/2458197e-4fb3-4f07-a752-5578418389c0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/2458197e-4fb3-4f07-a752-5578418389c0.png)
 
 * Use an email template like the following to send the code to the user:
     
@@ -102,7 +102,7 @@ The user´s name, the email address (for returning/registered customers), and th
 
 Use a simple check to verify the code and return a Boolean value the topic.
 
-![]({{site.baseurl}}/images/clq80jcqw000i08ju3yew0dvp.md/44382631-3a35-4c4c-b3af-71518eea635a.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clq80jcqw000i08ju3yew0dvp.md/44382631-3a35-4c4c-b3af-71518eea635a.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-01-13-add-a-copilot-studio-bot-to-dynamics-365-customer-service-for-improved-assistance.md
+++ b/holgerimbery/_posts/2024-01-13-add-a-copilot-studio-bot-to-dynamics-365-customer-service-for-improved-assistance.md
@@ -66,7 +66,7 @@ To accomplish this, follow these steps:
 
 In Microsoft Copilot Studio, edit your Bot. Select **Settings** and **Customer Engagement Hub in the navigation menu**, then choose the **Omnichannel** tile.
 
-![]({{site.baseurl}}/images/clrc0c4mu000008l0gwwb99it.md/e8100e43-70d4-4599-a25d-7c53a0e101ff.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clrc0c4mu000008l0gwwb99it.md/e8100e43-70d4-4599-a25d-7c53a0e101ff.png)
 
 Click **Connect**.
 
@@ -190,7 +190,7 @@ To achieve this in Copilot Studio, follow these steps:
 
 Following these steps ensures that your Bot is appropriately configured to end a conversation when a customer closes the chat window, providing a seamless and controlled user experience.
 
-![Configure end conversation topic in Copilot Studio.]({{site.baseurl}}/images/clrc0c4mu000008l0gwwb99it.md/end-bot-conversation.png)
+![Configure end conversation topic in Copilot Studio.](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clrc0c4mu000008l0gwwb99it.md/end-bot-conversation.png)
 
 1. Navigate to the topic where you need to trigger the conversation-ending topic in Omnichannel for Customer Service and use the **Go to another topic** option in **Add a node**.
     

--- a/holgerimbery/_posts/2024-01-18-how-human-handover-in-chatbots-improves-customer-service.md
+++ b/holgerimbery/_posts/2024-01-18-how-human-handover-in-chatbots-improves-customer-service.md
@@ -62,7 +62,7 @@ This chatbot platform assists users in creating and deploying chatbots for vario
 
 Microsoft introduced numerous new handover targets and rebranded Power Virtual Agents to CoPilot Studio. All major players are now covered.
 
-![]({{site.baseurl}}/images/clrxhz1to000009lf6mpfduku.md/7936016a-7075-4b41-a10c-4769f2b6acea.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clrxhz1to000009lf6mpfduku.md/7936016a-7075-4b41-a10c-4769f2b6acea.png)
 
 ### Microsoft Dynamics Customer Service
 

--- a/holgerimbery/_posts/2024-02-25-the-evolution-of-interaction-an-essay-on-copilot-graph-grounded-chat.md
+++ b/holgerimbery/_posts/2024-02-25-the-evolution-of-interaction-an-essay-on-copilot-graph-grounded-chat.md
@@ -34,7 +34,7 @@ starting with the usage on Microsoft's CoPilot Website: https://copilot.microsof
 
 ### Available for everyone
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/70bdb31a-f860-4849-be49-a33e95a7c04e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/70bdb31a-f860-4849-be49-a33e95a7c04e.png)
 
 For anyone looking to find the correct information, create unique content, and increase productivity, Copilot is available for use. With your free Microsoft account, you can:
 
@@ -51,7 +51,7 @@ For anyone looking to find the correct information, create unique content, and i
 
 ### Available for Individuals as a paid addon for Microsoft 365 Personal or Family subscribers
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/fd53ec0f-6b83-4fc5-9fba-0f78499815fd.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/fd53ec0f-6b83-4fc5-9fba-0f78499815fd.png)
 
 For those seeking enhanced performance and creative capabilities. This monthly subscription includes everything in Copilot, plus:
 
@@ -68,7 +68,7 @@ For those seeking enhanced performance and creative capabilities. This monthly s
 
 When organizations and employees utilize generative AI services, it's crucial to comprehend how these services manage user and chat data. Since employee chats might contain sensitive information, Copilot is specifically designed to safeguard this data, as demonstrated here:
 
-![source Microsoft: Commercial Data Protection]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/90f221f5-bdf6-409b-b93b-db15f46269ea.png)
+![source Microsoft: Commercial Data Protection](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/90f221f5-bdf6-409b-b93b-db15f46269ea.png)
 
 <center>source Microsoft: Commercial Data Protection</center>
 
@@ -85,11 +85,11 @@ When organizations and employees utilize generative AI services, it's crucial to
 * Advertising shown to Entra ID users is not targeted based on workplace identity or chat history.
     
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/1e5daf46-447d-402f-83b5-e0d7ab4739d7.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/1e5daf46-447d-402f-83b5-e0d7ab4739d7.png)
 
 <center> as website or as web app </center>
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/efa02edb-a876-4aac-806f-3ea9f37e5879.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/efa02edb-a876-4aac-806f-3ea9f37e5879.png)
 
 <center> Build in in your edge browsers bar on the right side </center>
 
@@ -133,15 +133,15 @@ Copilot for Microsoft 365 adds three things:
 > 
 > No, therefor you need Microsoft 365 CoPilot (paid)
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/c1c216f7-95e6-4204-8576-6c39cffef0e6.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/c1c216f7-95e6-4204-8576-6c39cffef0e6.png)
 
 <center> as website or as web app </center>
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/13259726-5f4d-4689-af53-dbfbeb79254e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/13259726-5f4d-4689-af53-dbfbeb79254e.png)
 
 <center> Build in in your edge browsers bar on the right side </center>
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/d8ab5a8b-c4bc-448d-bb84-5747e9a7a3b3.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/d8ab5a8b-c4bc-448d-bb84-5747e9a7a3b3.png)
 
 <center> within Microsoft Teams </center>
 
@@ -152,27 +152,27 @@ Copilot for Microsoft 365 adds three things:
 * Press the three dots on top-right
     
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/e3fadf4a-651e-4ba3-9076-4e6df139917e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/e3fadf4a-651e-4ba3-9076-4e6df139917e.png)
 
 * select "Apps" and "Install this site as an app."
     
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/2911c03d-8425-40bf-bb55-b7a5489348d8.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/2911c03d-8425-40bf-bb55-b7a5489348d8.png)
 
 * please give it a name
     
-* ![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/7ea998a5-25f4-433f-9a4a-714a73a93cd3.png)
+* ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/7ea998a5-25f4-433f-9a4a-714a73a93cd3.png)
     
     Pin it to your taskbar and Start menu and start it with your device login
     
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/bff0b50e-d1c1-4223-996b-7f271a761b5a.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/bff0b50e-d1c1-4223-996b-7f271a761b5a.png)
 
 ## Entering Prompts via spoken words
 
 Using Copilot through voice commands provides several advantages, such as enhanced productivity, hands-free coding, inclusivity, and efficiency. Voice commands can help streamline tasks, enabling developers to code without a keyboard, which can reduce physical fatigue and support individuals with disabilities. Voice coding fosters greater inclusivity in software development and encourages individuals with disabilities to engage in coding activities. Copilot's versatility makes it an adaptable tool that caters to different needs and preferences, making technology more accessible and convenient. By using voice commands, you can quickly and efficiently tackle daily tasks, boost productivity, unlock creativity, and enhance your understanding of information.
 
-![]({{site.baseurl}}/images/clt1it1gu000409l95y1155ek.md/05464cfd-7026-4b6e-b243-70b1e9dac817.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clt1it1gu000409l95y1155ek.md/05464cfd-7026-4b6e-b243-70b1e9dac817.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-03-02-microsoft-365-graph-grounded-chat-prompts.md
+++ b/holgerimbery/_posts/2024-03-02-microsoft-365-graph-grounded-chat-prompts.md
@@ -67,7 +67,7 @@ Discover information and obtain answers swiftly, even if you cannot recall the l
 
 ## Use this in Microsoft Teams
 
-![]({{site.baseurl}}/images/clta3cs5m000009kx1xsg24ps.md/515ad0b3-9286-42e7-949d-63995a008440.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clta3cs5m000009kx1xsg24ps.md/515ad0b3-9286-42e7-949d-63995a008440.png)
 
 1. Go to **Apps** on the left side of Teams.
     

--- a/holgerimbery/_posts/2024-03-09-enjoy-copilots-writing-assistance-anywhere-in-your-browser-at-no-extra-charge.md
+++ b/holgerimbery/_posts/2024-03-09-enjoy-copilots-writing-assistance-anywhere-in-your-browser-at-no-extra-charge.md
@@ -26,15 +26,15 @@ Copilot is an intelligent AI assistant that simplifies workflow and increases pr
 * activate "**Use Compose (AI-writing) on the web"**
     
 
-![]({{site.baseurl}}/images/cltjq7yta00060ajo2sdfctny.md/1624b2dc-c0a8-42a6-9de3-54516c03d2ec.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltjq7yta00060ajo2sdfctny.md/1624b2dc-c0a8-42a6-9de3-54516c03d2ec.png)
 
 How to use it
 
 Select your text and wait a fraction of a second for the "Rewrite with CoPilot" option to appear, or press "ALT+I".
 
-![]({{site.baseurl}}/images/cltjq7yta00060ajo2sdfctny.md/6881b3f9-5d88-46ba-a493-d45e10bb0409.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltjq7yta00060ajo2sdfctny.md/6881b3f9-5d88-46ba-a493-d45e10bb0409.png)
 
-![]({{site.baseurl}}/images/cltjq7yta00060ajo2sdfctny.md/5d1c992b-4ff2-4c88-925d-0ccb21e930d0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltjq7yta00060ajo2sdfctny.md/5d1c992b-4ff2-4c88-925d-0ccb21e930d0.png)
 
 You can replace your selected text with the generated one or adjust the generated text's length and tone.  
 Please be aware that the generated content needs to be proofread as it might not be correct.

--- a/holgerimbery/_posts/2024-03-16-using-microsoft-copilot-in-word.md
+++ b/holgerimbery/_posts/2024-03-16-using-microsoft-copilot-in-word.md
@@ -28,11 +28,11 @@ Copilot in Word is not just a simple text generator. It is an innovative and cre
 
 Copilot can assist you in creating or editing documents effortlessly. You will notice the "Draft with Copilot" option when you begin a new document or line.
 
-![]({{site.baseurl}}/images/cltu3j4jg000209l22qnqeb1m.md/c3cfefcb-c62b-4744-b602-fe31891a87f2.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltu3j4jg000209l22qnqeb1m.md/c3cfefcb-c62b-4744-b602-fe31891a87f2.png)
 
 You can provide Copilot with a simple or complex description of what you wish to write. For instance, you might say "Write an essay about dad jokes" or "Create a paragraph about time management".
 
-![]({{site.baseurl}}/images/cltu3j4jg000209l22qnqeb1m.md/a493d032-b85c-4835-9444-21f0d7021d2b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltu3j4jg000209l22qnqeb1m.md/a493d032-b85c-4835-9444-21f0d7021d2b.png)
 
 If you have a Copilot for Microsoft365 license, you can reference up to three of your files to help guide Copilot's drafting. Use the "Reference your content" button or type "/" followed by the file name in the compose box. This feature only accesses the files you select, ensuring your data remains private.
 
@@ -50,11 +50,11 @@ Rewriting and editing your documents can often take more time and effort than wr
 
 To rewrite text or convert it into a table, highlight the text in your document. Next, click the **Copilot** icon located in the left margin next to your text. Select **Rewrite** from the menu to see new versions suggested by Copilot. If you want to tweak Copilot's suggestions, click **Adjust tone** or **Regenerate** to receive a fresh set of options.
 
-![]({{site.baseurl}}/images/cltu3j4jg000209l22qnqeb1m.md/d68c5880-e386-4aed-a4d2-2bf74922c8c0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltu3j4jg000209l22qnqeb1m.md/d68c5880-e386-4aed-a4d2-2bf74922c8c0.png)
 
 If you want to visualize your text as a table, after highlighting the text, click the **Copilot** icon in the left margin. Select **Visualize as a table** from the menu, and Copilot will convert the text into a table format. You can click **Regenerate** for a new table or **Discard** to remove it.
 
-![]({{site.baseurl}}/images/cltu3j4jg000209l22qnqeb1m.md/4b37d09f-3dd6-4507-98e7-4a5ddc588629.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltu3j4jg000209l22qnqeb1m.md/4b37d09f-3dd6-4507-98e7-4a5ddc588629.png)
 
 To customize the table, use the Copilot compose box to specify adjustments, such as "*Add an empty third column.*"
 
@@ -64,13 +64,13 @@ To customize the table, use the Copilot compose box to specify adjustments, such
 
 You can access the **Copilot** feature by clicking on the Copilot icon in the **Home** tab of the ribbon. This helpful tool can answer both broad and specific questions about your document. You can engage in back-and-forth conversations to refine your queries, get summaries or detailed information about your document's content, or ask it to create ideas, tables, or lists that you can then copy and paste into your document.
 
-![]({{site.baseurl}}/images/cltu3j4jg000209l22qnqeb1m.md/2e011281-f0e5-4af1-9acf-bcc34dc75220.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltu3j4jg000209l22qnqeb1m.md/2e011281-f0e5-4af1-9acf-bcc34dc75220.png)
 
 When you ask for summaries or have questions about your document, Copilot will give you answers, references, and citations from where it got its information.
 
-![]({{site.baseurl}}/images/cltu3j4jg000209l22qnqeb1m.md/c0b4db8b-9b82-46ca-8e0b-b03de0eb0936.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltu3j4jg000209l22qnqeb1m.md/c0b4db8b-9b82-46ca-8e0b-b03de0eb0936.png)
 
-![]({{site.baseurl}}/images/cltu3j4jg000209l22qnqeb1m.md/2d2f0754-01cd-4a89-aae5-290725523afd.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cltu3j4jg000209l22qnqeb1m.md/2d2f0754-01cd-4a89-aae5-290725523afd.png)
 
 ## Sample prompts
 

--- a/holgerimbery/_posts/2024-03-23-utilize-copilot-for-microsoft-365-to-enhance-the-effectiveness-of-your-email.md
+++ b/holgerimbery/_posts/2024-03-23-utilize-copilot-for-microsoft-365-to-enhance-the-effectiveness-of-your-email.md
@@ -38,7 +38,7 @@ Drafting in Outlook for Microsoft 365 is currently available in new Outlook for 
 
 4. In the Copilot box, enter your prompt. For instance, *"Let the team know we decided to meet in our headquarters meeting room, 'Redmond,' next Wednesday at 2 pm to discuss the OKRs."*
 
-    ![]({{site.baseurl}}/images/clu40y6tb000f09l15cm4202b.md/6841eda4-d638-4206-bb84-f203896cd598.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clu40y6tb000f09l15cm4202b.md/6841eda4-d638-4206-bb84-f203896cd598.png)
 
 5. Click **Generate options** to pick your preferred length and tone.
 
@@ -47,7 +47,7 @@ Drafting in Outlook for Microsoft 365 is currently available in new Outlook for 
 7. Check the message. If it's not exactly what you want, click **Regenerate draft** for a new version.
 
 
-![]({{site.baseurl}}/images/clu40y6tb000f09l15cm4202b.md/d08156ab-9f70-4fe7-860c-b3aeade1e07d.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clu40y6tb000f09l15cm4202b.md/d08156ab-9f70-4fe7-860c-b3aeade1e07d.png)
 
 8. If you want to start again, change your prompt and click **Generate**.
    
@@ -87,7 +87,7 @@ In New Outlook and web versions of Outlook, Draft with Copilot doesn't support m
 4. If you like any or all of the suggestions, incorporate the feedback into the draft. When you are satisfied, send your email.
    
 
-![]({{site.baseurl}}/images/clu40y6tb000f09l15cm4202b.md/b93aabd8-56b2-4960-8443-88c1f8f2b214.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clu40y6tb000f09l15cm4202b.md/b93aabd8-56b2-4960-8443-88c1f8f2b214.png)
 
 ## What are the limitations of Copilot in Outlook, and how can users minimize their impact when using the system?
 
@@ -114,7 +114,7 @@ The way you ask your CoPilot for help is critical, including the following point
 * name the source
   
 
-![source Microsoft training material]({{site.baseurl}}/images/clu40y6tb000f09l15cm4202b.md/e3811861-5cf5-4562-be4c-99da46ded99c.png)
+![source Microsoft training material](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clu40y6tb000f09l15cm4202b.md/e3811861-5cf5-4562-be4c-99da46ded99c.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-04-06-improve-your-powerpoint-slides-with-creativity-tools-from-microsoft-365-copilot.md
+++ b/holgerimbery/_posts/2024-04-06-improve-your-powerpoint-slides-with-creativity-tools-from-microsoft-365-copilot.md
@@ -29,7 +29,7 @@ Within the PowerPoint environment, Copilot for Microsoft 365 offers the followin
 
 ## Create a new presentation with Copilot in PowerPoint
 
-![]({{site.baseurl}}/images/clunbwcz5000208k48vytba7l.md/5551a4c5-dd97-4e84-abb7-f67de5a65793.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clunbwcz5000208k48vytba7l.md/5551a4c5-dd97-4e84-abb7-f67de5a65793.png)
 
 1. Open PowerPoint and create a new presentation.
     
@@ -44,7 +44,7 @@ Within the PowerPoint environment, Copilot for Microsoft 365 offers the followin
 
 You can edit the presentation to fit your needs better, ask Copilot to add a slide, or start anew with a more detailed prompt. For instance, *"Create a presentation about adopting Copilot for Microsoft 365 using examples and best practice examples"*
 
-![]({{site.baseurl}}/images/clunbwcz5000208k48vytba7l.md/bae034d5-247b-4dfd-b42d-eb2c03ee73ac.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clunbwcz5000208k48vytba7l.md/bae034d5-247b-4dfd-b42d-eb2c03ee73ac.png)
 
 ## Create a presentation from a file with Copilot
 
@@ -68,13 +68,13 @@ If the file picker doesn't appear type a front slash (/) to cause it to pop up.
 * Edit the presentation to suit your needs, ask Copilot to add a slide, organize your presentation, or add images.
     
 
-![]({{site.baseurl}}/images/clunbwcz5000208k48vytba7l.md/0df19df7-5877-45ba-984f-71ebb80c2144.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clunbwcz5000208k48vytba7l.md/0df19df7-5877-45ba-984f-71ebb80c2144.png)
 
 ## Add a slide or image to your presentation with Copilot in PowerPoint
 
 If you need to include a slide about license details in your presentation, simply ask Copilot in PowerPoint to “**Add a slide** about licensing details,” and it will create the slide for you.
 
-![]({{site.baseurl}}/images/clunbwcz5000208k48vytba7l.md/5351cd3f-073b-4738-b47b-c0e9cc4292fb.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clunbwcz5000208k48vytba7l.md/5351cd3f-073b-4738-b47b-c0e9cc4292fb.png)
 
 Copilot can also help improve your presentation. Ask Copilot to “**Add an image** of a person in an office,” and Copilot will find the ideal image to enhance your slide.
 

--- a/holgerimbery/_posts/2024-04-13-streamline-your-excel-work-effective-data-management-with-copilot.md
+++ b/holgerimbery/_posts/2024-04-13-streamline-your-excel-work-effective-data-management-with-copilot.md
@@ -41,7 +41,7 @@ Copilot for Microsoft 365 can show insights based on your data or a specific qu
     
 4. Select **Analyze** and choose a suggested prompt. You can also describe what you’d like to know by asking a question about your data in your own words.
     
-    ![]({{site.baseurl}}/images/cluxstsl2000h08l1d0go32kn.md/ee163239-d00c-4b76-8efc-a2b501d74c02.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cluxstsl2000h08l1d0go32kn.md/ee163239-d00c-4b76-8efc-a2b501d74c02.png)
     
 5. Select **Send**. Copilot analyzes your data to show insights as charts, PivotTable objects, summaries, trends, or outliers.
     
@@ -55,7 +55,7 @@ Copilot for Microsoft 365 can show insights based on your data or a specific qu
 **Example:**  
 Show total 'Engaged Users' by 'Launch Date' as a line chart
 
-![]({{site.baseurl}}/images/cluxstsl2000h08l1d0go32kn.md/bc9c40e1-54c6-4b5d-93f0-1a4e3b9fef0e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cluxstsl2000h08l1d0go32kn.md/bc9c40e1-54c6-4b5d-93f0-1a4e3b9fef0e.png)
 
 ## Highlight, sort, and filter your data with Copilot in Excel
 
@@ -75,12 +75,12 @@ Next, instruct Copilot on how you want to modify the table to enhance the visibi
 **Example:**  
 Show items with 'Campaign Owner' of 'Halima, Yakubu'
 
-![]({{site.baseurl}}/images/cluxstsl2000h08l1d0go32kn.md/088e4ba8-cbbe-421b-89d3-f617bfcde9ce.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cluxstsl2000h08l1d0go32kn.md/088e4ba8-cbbe-421b-89d3-f617bfcde9ce.png)
 
 **Example:**  
 Percentage distribution of 'Campaign Type'
 
-![]({{site.baseurl}}/images/cluxstsl2000h08l1d0go32kn.md/7240d6d1-b741-4ae3-a7da-063bd8feebb7.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cluxstsl2000h08l1d0go32kn.md/7240d6d1-b741-4ae3-a7da-063bd8feebb7.png)
 
 ## Create formula columns using Copilot in Excel
 
@@ -101,9 +101,9 @@ As with all AI-generated content, it's crucial to review, edit, and confirm the 
 **Example:**  
 *Add a column that calculates the total profit for each marketing campaign*
 
-![]({{site.baseurl}}/images/cluxstsl2000h08l1d0go32kn.md/4098c8dd-9d1e-4869-bc2d-e5853b5090ed.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cluxstsl2000h08l1d0go32kn.md/4098c8dd-9d1e-4869-bc2d-e5853b5090ed.png)
 
-![]({{site.baseurl}}/images/cluxstsl2000h08l1d0go32kn.md/efa7e4e3-57b2-4da6-8ad0-210e30b541d0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cluxstsl2000h08l1d0go32kn.md/efa7e4e3-57b2-4da6-8ad0-210e30b541d0.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-04-20-enhancing-whiteboard-capabilities-with-copilot.md
+++ b/holgerimbery/_posts/2024-04-20-enhancing-whiteboard-capabilities-with-copilot.md
@@ -18,7 +18,7 @@ Introducing Copilot in Whiteboard - an innovative tool that revolutionizes how y
 
 Copilot in Whiteboard is available in the Whiteboard desktop app, web browser, iPad, and Teams client to users with a Copilot for Microsoft 365 license. It supports various languages, including English, Spanish, Japanese, French, German, Portuguese, Italian, and Chinese Simplified.
 
-![]({{site.baseurl}}/images/clv7ujs2v000009jk6mx4frro.md/541e6a5c-2474-4bcd-a787-8459b11f1a1d.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clv7ujs2v000009jk6mx4frro.md/541e6a5c-2474-4bcd-a787-8459b11f1a1d.png)
 
 ### Suggest ideas
 
@@ -30,7 +30,7 @@ Getting started with a new plan can be challenging, especially when you have a b
         
     
 
-![]({{site.baseurl}}/images/clv7ujs2v000009jk6mx4frro.md/c69c5721-55c4-4f19-9edf-c205fa71fa6f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clv7ujs2v000009jk6mx4frro.md/c69c5721-55c4-4f19-9edf-c205fa71fa6f.png)
 
 * **Right-click menu**
     
@@ -43,9 +43,9 @@ Getting started with a new plan can be challenging, especially when you have a b
 
 After submitting your prompt, Copilot will display several suggestions in a pop-up window. You can remove a suggestion by clicking the **X** next to it. Click **Insert** to add the suggestions to the Whiteboard, **Generate more** to get additional suggestions, or **Edit** to modify your prompt.
 
-![]({{site.baseurl}}/images/clv7ujs2v000009jk6mx4frro.md/c2a8d248-fd87-4ee6-ab48-f6fb99707c31.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clv7ujs2v000009jk6mx4frro.md/c2a8d248-fd87-4ee6-ab48-f6fb99707c31.png)
 
-![]({{site.baseurl}}/images/clv7ujs2v000009jk6mx4frro.md/a2000885-f65e-4cb7-9c50-525de0360ee6.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clv7ujs2v000009jk6mx4frro.md/a2000885-f65e-4cb7-9c50-525de0360ee6.png)
 
 ## Organize the ideas
 
@@ -58,13 +58,13 @@ It can be challenging to understand if you have a whiteboard filled with ideas t
     * Click **Categorize** to start the process or **Cancel** to stop and exit the process.
         
 
-![]({{site.baseurl}}/images/clv7ujs2v000009jk6mx4frro.md/0e938696-7970-48aa-afcd-0d1d6e8b62e2.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clv7ujs2v000009jk6mx4frro.md/0e938696-7970-48aa-afcd-0d1d6e8b62e2.png)
 
-![]({{site.baseurl}}/images/clv7ujs2v000009jk6mx4frro.md/32f4c967-a225-4826-9f17-54d5f8d60c57.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clv7ujs2v000009jk6mx4frro.md/32f4c967-a225-4826-9f17-54d5f8d60c57.png)
 
 Copilot is a note-taking tool that categorizes your notes into different groups with headings using different colors. After Copilot categorizes your notes, you can either Keep them, Revert them to being uncategorized, or Regenerate Copilot’s categorization if you're not happy with the result. Once your notes are categorized, you can edit, move, and delete them, as well as modify the headings as per your needs.
 
-![]({{site.baseurl}}/images/clv7ujs2v000009jk6mx4frro.md/3994e644-4be3-4a2a-9444-61d1d351fbc0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clv7ujs2v000009jk6mx4frro.md/3994e644-4be3-4a2a-9444-61d1d351fbc0.png)
 
 ## Understand your ideas
 
@@ -86,7 +86,7 @@ Accessing the Summarize feature in Whiteboard is possible through several method
 
 Copilot is designed to compile a summary of the notes taken on the Whiteboard and seamlessly integrate them into a Loop component. This component can then be conveniently edited, duplicated, and distributed among colleagues or customers.
 
-![]({{site.baseurl}}/images/clv7ujs2v000009jk6mx4frro.md/000f6405-234d-4819-bf15-ef94efe6f496.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clv7ujs2v000009jk6mx4frro.md/000f6405-234d-4819-bf15-ef94efe6f496.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-04-27-enhancing-customer-connections-the-power-of-preferred-agent-routing-in-dynamics-365-customer-service.md
+++ b/holgerimbery/_posts/2024-04-27-enhancing-customer-connections-the-power-of-preferred-agent-routing-in-dynamics-365-customer-service.md
@@ -33,7 +33,7 @@ To configure preferred agent routing, you must possess the Omnichannel Administr
     
 2. On the next page, click **Manage** next to **Preferred Agent Routing**.
     
-    ![]({{site.baseurl}}/images/clvhthjnp000609mjgdcudpms.md/17e99276-3f69-4a02-ab9f-9917f02289eb.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvhthjnp000609mjgdcudpms.md/17e99276-3f69-4a02-ab9f-9917f02289eb.png)
     
       
     
@@ -53,7 +53,7 @@ To configure preferred agent routing, you must possess the Omnichannel Administr
         
     3. Click **Add User** to link agents to the contact.
         
-        ![]({{site.baseurl}}/images/clvhthjnp000609mjgdcudpms.md/e7c08836-d983-4ed0-97e1-9610f92992a6.png)
+        ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvhthjnp000609mjgdcudpms.md/e7c08836-d983-4ed0-97e1-9610f92992a6.png)
         
           
         

--- a/holgerimbery/_posts/2024-05-04-revolutionizing-customer-service-the-power-of-copilot-studio-voice-copilots-in-dynamics-365.md
+++ b/holgerimbery/_posts/2024-05-04-revolutionizing-customer-service-the-power-of-copilot-studio-voice-copilots-in-dynamics-365.md
@@ -32,11 +32,11 @@ Copilot Studio's voice bots offer several key features, including:
 
 You need to create a classic bot to use it in Dynamics 365 Customer Service Omnichannel.
 
-![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/89cc2684-7aa7-4b24-b7aa-c8ee65b45eb4.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/89cc2684-7aa7-4b24-b7aa-c8ee65b45eb4.png)
 
-![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/03001c35-f38d-479b-b47c-f24adac4b4cf.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/03001c35-f38d-479b-b47c-f24adac4b4cf.png)
 
-![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/ec1acbe2-6d57-4cf8-8a33-41061545d770.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/ec1acbe2-6d57-4cf8-8a33-41061545d770.png)
 
 ## **Prerequisites**
 
@@ -53,13 +53,13 @@ For the Copilot Studio bot to function properly, the following prerequisites are
     
 * Choose a bot from the Name dropdown menu in the Add Bot pane.
     
-    ![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/36321334-b52d-4e05-9342-ca0bf58aa470.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/36321334-b52d-4e05-9342-ca0bf58aa470.png)
     
 * Select **Save and close**. The bot is added to the workstream.
     
-    ![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/df23e4fd-d0d1-4f2a-9307-ddd879c0ed24.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/df23e4fd-d0d1-4f2a-9307-ddd879c0ed24.png)
     
-    ![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/b906290b-759d-4c27-aea5-f4b9a7ad8db0.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/b906290b-759d-4c27-aea5-f4b9a7ad8db0.png)
     
 
 ### **Configure handoff from Copilot Studio to Omnichannel for Customer Service**
@@ -86,16 +86,16 @@ For the Copilot Studio bot to function properly, the following prerequisites are
             
         * Enter the name of your bot, and then select **Register**.
             
-        * ![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/f6294a7f-fefb-418d-93a8-6180d0301abe.png)
+        * ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/f6294a7f-fefb-418d-93a8-6180d0301abe.png)
             
             Copy the **Application ID** to the clipboard.
             
-            ![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/50d50e9f-8bb7-468f-8cd1-a2d0631221b1.png)
+            ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/50d50e9f-8bb7-468f-8cd1-a2d0631221b1.png)
             
     * Navigate to Copilot Studio, insert the copied ID into the Application ID field, and then choose 'Add your bot'. Once the bot is added, a confirmation message will appear, and the bot will be listed.
         
     
-    ![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/85a520cf-8726-4529-adeb-4fd92919b3b0.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/85a520cf-8726-4529-adeb-4fd92919b3b0.png)
     
     To use details from Dynamics 365 Customer Service within the custom copilot, install the addon packages:  
     [  
@@ -115,7 +115,7 @@ For the Copilot Studio bot to function properly, the following prerequisites are
 
 Using CallerID as an identifier, the system greets the caller with the name stored in the associated record in Dynamics.
 
-![]({{site.baseurl}}/images/clvrrpnz3000409la52j69nui.md/be1a2e25-e073-4024-84cd-ce9a1eeeff49.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clvrrpnz3000409la52j69nui.md/be1a2e25-e073-4024-84cd-ce9a1eeeff49.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-07-06-copilot-for-dynamics-365-customer-service-a-comprehensive-guide.md
+++ b/holgerimbery/_posts/2024-07-06-copilot-for-dynamics-365-customer-service-a-comprehensive-guide.md
@@ -22,21 +22,21 @@ Microsoft Dynamics 365 Customer Service has introduced a game-changing feature k
 
 One of the standout features of Copilot is its ability to answer questions. When you sign in to any customer service agent apps, Copilot is ready and waiting in the right side panel with the 'Ask a question' tab. This feature allows you to ask free-form questions, just as you would ask a colleague or supervisor. Copilot then provides the most relevant answer from the knowledge sources your organization has made available.
 
-![]({{site.baseurl}}/images/cly9vp2hn000c09ik28ble006.md/171ac956-e2bb-4228-bcb6-67cfef752370.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cly9vp2hn000c09ik28ble006.md/171ac956-e2bb-4228-bcb6-67cfef752370.png)
 
-![]({{site.baseurl}}/images/cly9vp2hn000c09ik28ble006.md/79ed33a3-6231-4234-bb88-0be76da363b8.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cly9vp2hn000c09ik28ble006.md/79ed33a3-6231-4234-bb88-0be76da363b8.png)
 
 ### Drafting Emails
 
 Another significant feature of Copilot is its ability to assist in drafting emails. It also provides a chat interface that allows quick summaries of sales opportunities and leads, updates, meeting preparations, account-related news, and much more.
 
-![]({{site.baseurl}}/images/cly9vp2hn000c09ik28ble006.md/d4e68180-8646-4d14-9bd6-d9bbe05ba09c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cly9vp2hn000c09ik28ble006.md/d4e68180-8646-4d14-9bd6-d9bbe05ba09c.png)
 
 ### Summarizing Cases and Conversations
 
 Copilot can summarize cases and conversations. The case summary includes critical information such as the case title, customer, subject, product, priority, case type, and description. For conversations, Copilot provides context and relays your steps to solve the issue.
 
-![]({{site.baseurl}}/images/cly9vp2hn000c09ik28ble006.md/1cfa63af-51c5-492b-8efd-49605e43772f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cly9vp2hn000c09ik28ble006.md/1cfa63af-51c5-492b-8efd-49605e43772f.png)
 
 ### Generating Knowledge Drafts from Cases
 
@@ -58,7 +58,7 @@ With the Copilot analytics dashboard, supervisors and customer service managers 
 
 To enable the Copilot features, you must have the role of System Administrator.
 
-![]({{site.baseurl}}/images/cly9vp2hn000c09ik28ble006.md/15b116b5-651b-4b78-a503-a9758c6bf45d.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cly9vp2hn000c09ik28ble006.md/15b116b5-651b-4b78-a503-a9758c6bf45d.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-07-13-unleashing-the-power-of-ai-with-copilot-in-dynamics-365-sales.md
+++ b/holgerimbery/_posts/2024-07-13-unleashing-the-power-of-ai-with-copilot-in-dynamics-365-sales.md
@@ -26,7 +26,7 @@ Copilot features a chat interface that enables sellers to obtain summaries of th
 
 Additionally, Copilot can summarize email exchanges and allows users to view and attach the summary as a note within a record. This functionality is especially beneficial for customer interactions via email, where manual record updates can be labor-intensive and susceptible to mistakes.
 
-![]({{site.baseurl}}/images/clyjwpatk00030alddh6z4qq8.md/f8760f17-55fd-4182-aa09-91c16febbf1b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyjwpatk00030alddh6z4qq8.md/f8760f17-55fd-4182-aa09-91c16febbf1b.png)
 
 e.g., Chat with Copilot in a side pane
 

--- a/holgerimbery/_posts/2024-07-20-enhance-customer-service-with-dynamics-365s-integrated-voice-channel.md
+++ b/holgerimbery/_posts/2024-07-20-enhance-customer-service-with-dynamics-365s-integrated-voice-channel.md
@@ -34,21 +34,21 @@ Create Azure Communication Resource
 * Navigate to [portal.azure.com](http://portal.azure.com), create a new Resource Group, and click the "+Create" button.
     
 
-![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/3944a3ea-cb53-4401-8c1d-eccd1e9ccd19.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/3944a3ea-cb53-4401-8c1d-eccd1e9ccd19.png)
 
 * Then, enter 'Communication' into the search bar or the 'Search the Marketplace' input field. Choose 'Communication Services' from the search results and click 'Create'.
     
 
-![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/a05ca81e-4d74-4d5f-9274-21c66faa4995.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/a05ca81e-4d74-4d5f-9274-21c66faa4995.png)
 
 * Proceed to configure your new resource.
     
 
-![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/b66ad2bb-7aee-4efa-a3ea-ba3555ed64b3.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/b66ad2bb-7aee-4efa-a3ea-ba3555ed64b3.png)
 
 * Verify your new Resource
     
-    ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/6b48c6f4-78cd-498c-bac6-2a459632db16.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/6b48c6f4-78cd-498c-bac6-2a459632db16.png)
     
 
 ### Create an App Registration
@@ -56,16 +56,16 @@ Create Azure Communication Resource
 * Navigate to Microsoft Entra ID within [portal.azure.com](http://portal.azure.com) and select 'App Registration'.
     
 
-![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/8ef6a8ed-92ec-4778-86e1-b0f0e7453148.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/8ef6a8ed-92ec-4778-86e1-b0f0e7453148.png)
 
 * Click "+Add" and set up your new App Registration, as shown in the image below.
     
 
-![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/34c6506d-3f76-4b6c-986f-3b6036a05c70.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/34c6506d-3f76-4b6c-986f-3b6036a05c70.png)
 
 * Navigate to the created App Registration and add yourself as an owner.
     
-* ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/bcf2a106-f2ab-4920-aa6f-849368608443.png)
+* ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/bcf2a106-f2ab-4920-aa6f-849368608443.png)
     
 
 ### Remember your Tenant ID
@@ -73,7 +73,7 @@ Create Azure Communication Resource
 * After registering your app, remember to note down your tenant ID for future reference; it will be highlighted in red in the image below.
     
 
-![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/23cbcf9b-cfa6-4819-af04-bd6278d980d6.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/23cbcf9b-cfa6-4819-af04-bd6278d980d6.png)
 
 ### Configure Direct Routing
 
@@ -82,27 +82,27 @@ Create Azure Communication Resource
 * Select "Add domain"
     
 
-![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/d7729097-262f-438b-902e-f30dd6f96bc7.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/d7729097-262f-438b-902e-f30dd6f96bc7.png)
 
 * You ought to have obtained some domain names from your direct routing provider. The subsequent step involves creating TXT records for domain verification. These records and additional details must be forwarded to your provider.
     
 * After verifying these domains, it should look as shown in the picture below.
     
-    ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/1964ea48-97e5-4e9a-9e2b-83a7b36d18bb.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/1964ea48-97e5-4e9a-9e2b-83a7b36d18bb.png)
     
     * Click on "Session Border Controllers" to add your provider's SBC. Therefore, you should have received a URI for at least one SBC and a port number.
         
     * The setup should resemble the image provided after integrating the Session Border Controllers (SBCs).
         
     
-    ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/b55a4aaa-b75f-494f-8297-1cebce6fc928.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/b55a4aaa-b75f-494f-8297-1cebce6fc928.png)
     
     * Next, configure your Voice Routes as outlined in Microsoft's documentation.
         
     * If you have just one SBC, you can establish a default route.
         
 
-![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/7380d1ac-809b-48d7-bb2a-145b9ef1f501.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/7380d1ac-809b-48d7-bb2a-145b9ef1f501.png)
 
 ### Start a test call
 
@@ -110,7 +110,7 @@ To ensure the Azure Communication Resource functions correctly, initiate a test 
 
 * Click on "Try Phone Calling," and enter your Caller ID and the number you want to call.
     
-    ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/2da1c246-93d3-443c-b526-d0b5ab76f29a.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/2da1c246-93d3-443c-b526-d0b5ab76f29a.png)
     
     * If everything is configured correctly, you will receive a call via Azure Communication Services.
         
@@ -123,7 +123,7 @@ To ensure the Azure Communication Resource functions correctly, initiate a test 
     
 * Click on "Channels", "Phone numbers" and "Manage"
     
-    ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/7c81c980-c7c9-4117-85af-73f09dbf005e.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/7c81c980-c7c9-4117-85af-73f09dbf005e.png)
     
     * Complete your channel setup by installing the Omnichannel for Customer Service app.
         
@@ -140,11 +140,11 @@ To ensure the Azure Communication Resource functions correctly, initiate a test 
         
         Once you have configured the Azure Communication Services resource, input your App Registration App ID (highlighted in red, paragraph "remember your App ID") and your Tenant ID into the 'Event Grid App ID' and 'Event Grid App Tenant ID' fields, respectively.
         
-        ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/e3b6d223-e480-4964-9fee-8c76a29e7f64.png)
+        ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/e3b6d223-e480-4964-9fee-8c76a29e7f64.png)
         
         The system will present three webhooks that need to be configured as "Event Grid Topics." (Marked in red)
         
-        ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/30713e57-f2d0-49c9-a764-1ac2fcf78dc6.png)
+        ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/30713e57-f2d0-49c9-a764-1ac2fcf78dc6.png)
         
 
 ### Add your Phone Numbers
@@ -155,7 +155,7 @@ To ensure the Azure Communication Resource functions correctly, initiate a test 
     
 * The result should look similar to the configuration below.
     
-    ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/43310ef0-1ece-494d-bc27-53d31044ecb2.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/43310ef0-1ece-494d-bc27-53d31044ecb2.png)
     
 ### Create your Event Grid System Topics
     
@@ -203,7 +203,7 @@ You must carry out the following three types of incoming/recording/SMS actions.
     
     Next, set the Endpoint Type to 'Web Hook'. For the Endpoint, click 'Select an endpoint' and input the webhook endpoint for incoming calls, recording, or SMS services.
     
-    ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/00555d69-dbe3-476f-9478-f7331cee41ef.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/00555d69-dbe3-476f-9478-f7331cee41ef.png)
     
     In the Additional Features tab, tick the 'Use Microsoft Entra Authentication' box and provide the following details:
     
@@ -212,11 +212,11 @@ You must carry out the following three types of incoming/recording/SMS actions.
     * Microsoft Entra Application ID or URI: Enter the application ID (from the app registration) for your Azure resource.
         
     
-    ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/1a6ea69d-978a-40f2-bf78-fe2b731d924c.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/1a6ea69d-978a-40f2-bf78-fe2b731d924c.png)
     
     * When done, it should look like the following.
         
-        ![]({{site.baseurl}}/images/clyuala0i000n09mmd9g527wn.md/849c5d0c-b12d-44ce-884b-62635cac0f10.png)
+        ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clyuala0i000n09mmd9g527wn.md/849c5d0c-b12d-44ce-884b-62635cac0f10.png)
         
 
 ## Workstreams and Queues

--- a/holgerimbery/_posts/2024-07-27-the-new-voice-capabilities-of-copilot-studio-a-comprehensive-overview.md
+++ b/holgerimbery/_posts/2024-07-27-the-new-voice-capabilities-of-copilot-studio-a-comprehensive-overview.md
@@ -44,7 +44,7 @@ Users must configure their Copilots for Voice in Copilot Studio to get started w
 
 create a new bot on https://copilotstudio.microsoft.com
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/9b73b744-ebf1-447c-b9c4-4c25502443a0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/9b73b744-ebf1-447c-b9c4-4c25502443a0.png)
 
 ### Configure Voice Settings
 
@@ -53,52 +53,52 @@ create a new bot on https://copilotstudio.microsoft.com
 * Mark "Use voice as a primary author mode"
     
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/da7563e8-5ff0-4d5c-b8d6-a47a969f829b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/da7563e8-5ff0-4d5c-b8d6-a47a969f829b.png)
 
 ### Configure Telefony Channel
 
 * Go to Channels &gt; Channels, click "Telephony" and activate it.
     
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/1e626750-6ade-4f4d-a975-75e2700cef29.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/1e626750-6ade-4f4d-a975-75e2700cef29.png)
 
 ### Configure Handover to Dynamics 365 Customer Service or Dynamics 365 Contact Center
 
 * go to Channels &gt; Customer Engagement Hub &gt; Dynamics 365 Customer Service
     
-    ![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/5e24c101-d8f7-4e7c-b065-1546fe2334b5.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/5e24c101-d8f7-4e7c-b065-1546fe2334b5.png)
     
 * If you have activated it, the result should look similar to the picture below.
     
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/42014edc-d8ec-43f8-8162-655654a24c32.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/42014edc-d8ec-43f8-8162-655654a24c32.png)
 
 * Navigate to the Dynamics 365 "Customer Service Admin Center" or "Contact Center Admin Center," proceed to your voice workstream, and click 'Add bot.'
     
 * Then, select the bot you have recently created. The outcome should resemble the screenshot provided.
     
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/a45eb71c-3f56-4f26-8d06-8fd47fe59bee.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/a45eb71c-3f56-4f26-8d06-8fd47fe59bee.png)
 
 ### Greet your calling customer by name
 
 To greet a caller by name, you can utilize the caller ID and an associated contact in Dynamics Customer Service by adding a variable to a text node.
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/78b6c953-b40b-4b5c-9e7b-35e1fb4e4604.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/78b6c953-b40b-4b5c-9e7b-35e1fb4e4604.png)
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/dcd07062-256b-4035-8aad-0017f567b467.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/dcd07062-256b-4035-8aad-0017f567b467.png)
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/f09f5e9f-fc17-49b8-bb51-33fd6063dab2.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/f09f5e9f-fc17-49b8-bb51-33fd6063dab2.png)
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/b935b8cf-dcc9-4efb-853f-7f6dc0771ab2.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/b935b8cf-dcc9-4efb-853f-7f6dc0771ab2.png)
 
 ## Testing Your Voice-Enabled Copilot
 
 Once the copilot is set up, users can test it using text inputs that simulate a user’s input through speech or DTMF. This allows users to see the speech response in the text output and verify voice features such as Barge-in and DTMF in their text input.
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/cce0c1c4-6785-465a-baa3-e9bc6b766cde.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/cce0c1c4-6785-465a-baa3-e9bc6b766cde.png)
 
-![]({{site.baseurl}}/images/clz3xugxg000209l8gr335ait.md/f5f14115-7e90-4ba9-b360-fd882ec7268d.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clz3xugxg000209l8gr335ait.md/f5f14115-7e90-4ba9-b360-fd882ec7268d.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-08-11-choosing-generative-ai-solutions-build-your-own-or-use-microsoft-copilot.md
+++ b/holgerimbery/_posts/2024-08-11-choosing-generative-ai-solutions-build-your-own-or-use-microsoft-copilot.md
@@ -28,7 +28,7 @@ Understanding the Contenders Microsoft Copilot is an AI-powered assistant integr
 
 On the other hand, Azure AI Studio is a comprehensive platform allowing developers to build custom AI solutions. It provides access to Azure AI Infrastructure, Machine Learning, Cognitive Services, and OpenAI Services in one centralized hub.
 
-![solving the "build or buy dilemma"]({{site.baseurl}}/images/clzpc5j4500060aladprtath3.md/4d2a9922-8945-4c08-a297-7443eab4038b.jpeg)
+![solving the "build or buy dilemma"](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzpc5j4500060aladprtath3.md/4d2a9922-8945-4c08-a297-7443eab4038b.jpeg)
 
 ## Criteria for Decision-Making
 

--- a/holgerimbery/_posts/2024-08-17-step-by-step-guide-to-launching-an-enterprise-chat-application-with-azure-ai-studio.md
+++ b/holgerimbery/_posts/2024-08-17-step-by-step-guide-to-launching-an-enterprise-chat-application-with-azure-ai-studio.md
@@ -58,73 +58,73 @@ The steps in this tutorial are:
 
 * To set up a new resource group and include an Azure OpenAI Resource, begin by navigating the Azure portal. Once there, create a new resource group, then add an Azure OpenAI Resource to this group.
   
-    ![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/2d177ac8-1f02-4774-acd0-582cfb5e7a7d.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/2d177ac8-1f02-4774-acd0-582cfb5e7a7d.png)
     
 * Navigate to Azure AI Studio and initiate the deployment of the large language models, provided that you have already established a hub and a project.
   
-    ![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/6037bbb5-6a60-4592-b2c8-ea08546ac1df.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/6037bbb5-6a60-4592-b2c8-ea08546ac1df.png)
     
 * Navigate to Project Playground, select Chat, and proceed to test the model.
   
-    ![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/951955fb-4fb3-4c16-8c9a-3b5ca04cf3ba.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/951955fb-4fb3-4c16-8c9a-3b5ca04cf3ba.png)
     
 
 ## Add Your Data
 
 * Select "Add your data" and proceed with the provided instructions.
   
-    ![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/dd9a87ed-c300-4538-a78a-4cdf643e5a5a.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/dd9a87ed-c300-4538-a78a-4cdf643e5a5a.png)
     
 * Select a storage container from an existing Azure Blob Storage and choose a previously established Azure AI Search service. Assign a descriptive name to your index. You can modify the Indexer Schedule at a later time if necessary.
   
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/4a149205-6142-4605-949b-8c3db3e24daa.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/4a149205-6142-4605-949b-8c3db3e24daa.png)
 
 * Please choose your type of search.
   
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/126a5168-370d-47ef-94a2-9fce74751323.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/126a5168-370d-47ef-94a2-9fce74751323.png)
 
 * Select the type of authentication for our system.
   
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/b714c315-cc42-425c-9a98-07a9db51ad10.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/b714c315-cc42-425c-9a98-07a9db51ad10.png)
 
 * Grab a cup of coffee or tea and hang tight—the data will be ready before your cup runs dry! :-)
   
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/2e7feb1d-688d-4a48-a848-063010a05bfe.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/2e7feb1d-688d-4a48-a848-063010a05bfe.png)
 
 **Test the Model With Your Data**
 
 * Check the chat interface to see if everything works with your data.
   
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/e2eb769b-c7ea-4720-a852-c89004a91a4b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/e2eb769b-c7ea-4720-a852-c89004a91a4b.png)
 
 ## **Deploy Your Web Application**
 
 * Select "Deploy to a web app" located above the chat window.
   
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/bb3b767f-c3ef-4516-985d-a94785551d69.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/bb3b767f-c3ef-4516-985d-a94785551d69.png)
 
 * Create the web app according to your preferences.
   
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/03d700f8-847e-4ec6-9474-336ae1d61a44.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/03d700f8-847e-4ec6-9474-336ae1d61a44.png)
 
 * Environment variables allow you to customize the web application to meet your requirements. Documentation and instructions for additional customizations are available on [GitHub](https://github.com/microsoft/sample-app-aoai-chatGPT).  
   
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/26b86e5b-755f-49b0-b970-7b518cc35672.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/26b86e5b-755f-49b0-b970-7b518cc35672.png)
 
 * The result will then look similar to this.
   
-    ![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/4c729912-1096-4cfb-8362-0e30c8641287.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/4c729912-1096-4cfb-8362-0e30c8641287.png)
     
 
-![]({{site.baseurl}}/images/clzxzun55000308kx5nm5bgl7.md/96a3b517-af5b-4aac-bb3c-4f9ab6f60ef5.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/clzxzun55000308kx5nm5bgl7.md/96a3b517-af5b-4aac-bb3c-4f9ab6f60ef5.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-10-21-easy-steps-to-create-multilingual-ivrs-with-copilot-studio-in-dynamics-365-customer-service-or-contactcenter.md
+++ b/holgerimbery/_posts/2024-10-21-easy-steps-to-create-multilingual-ivrs-with-copilot-studio-in-dynamics-365-customer-service-or-contactcenter.md
@@ -21,7 +21,7 @@ Leveraging Copilot Studio's built-in capabilities, you can create a multilingual
 
 Copilot Studio cannot create bots in the voice channel using multiple languages.
 
-![]({{site.baseurl}}/images/cm2iy07ml001y08me9sokaz7m.md/32feb528-28c0-4f03-ab15-ff2ed31e3fd1.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2iy07ml001y08me9sokaz7m.md/32feb528-28c0-4f03-ab15-ff2ed31e3fd1.png)
 
 ## How to create a multilingual IVR
 
@@ -29,7 +29,7 @@ You can create a bot for your Voice Channel in one language and utilize SSML tag
 
 * Begin by establishing a Workstream as a concierge service in your primary language. Then, connect the Workstream to the phone number you wish to make available to your customers.
     
-    ![]({{site.baseurl}}/images/cm2iy07ml001y08me9sokaz7m.md/d3921049-8b21-457a-81b5-48642e5140d2.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2iy07ml001y08me9sokaz7m.md/d3921049-8b21-457a-81b5-48642e5140d2.png)
     
 * Incorporate a multilingual voice into your Voice Profile for that particular Workstream.
     
@@ -39,7 +39,7 @@ You can create a bot for your Voice Channel in one language and utilize SSML tag
     
 * Add a Message Node as your IVR Text with SSML Tags to change the language.
     
-    ![]({{site.baseurl}}/images/cm2iy07ml001y08me9sokaz7m.md/5c9f01f4-f20f-4528-8078-03862e019db9.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2iy07ml001y08me9sokaz7m.md/5c9f01f4-f20f-4528-8078-03862e019db9.png)
     
     ```xml
     <voice name="en-US-AvaMultilingualNeural">
@@ -55,14 +55,14 @@ You can create a bot for your Voice Channel in one language and utilize SSML tag
     
 * Create a question node and a condition as described in the screenshots.
     
-    ![]({{site.baseurl}}/images/cm2iy07ml001y08me9sokaz7m.md/dda57bab-6c53-43f1-8cab-693959cb68b8.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2iy07ml001y08me9sokaz7m.md/dda57bab-6c53-43f1-8cab-693959cb68b8.png)
     
 
-![]({{site.baseurl}}/images/cm2iy07ml001y08me9sokaz7m.md/d21f3930-c384-4375-a47a-574cdad1827c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2iy07ml001y08me9sokaz7m.md/d21f3930-c384-4375-a47a-574cdad1827c.png)
 
 * Utilize the Transfer Conversation Node to forward calls for all languages other than your primary one to the "hidden" phone numbers associated with your workstreams in those languages. Do not forget to end the topic with an “End current topic” node.
     
-    ![]({{site.baseurl}}/images/cm2iy07ml001y08me9sokaz7m.md/bc82bef8-49c5-4d0a-9cd3-5f526991e47d.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2iy07ml001y08me9sokaz7m.md/bc82bef8-49c5-4d0a-9cd3-5f526991e47d.png)
     
     Once saved and published, the final result should mirror the dialogue in the attachment, noting that sound is absent between seconds 18 and 20.
     

--- a/holgerimbery/_posts/2024-10-27-enhance-your-copilot-for-microsoft-365-experience-when-plain-copilot-isnt-enough.md
+++ b/holgerimbery/_posts/2024-10-27-enhance-your-copilot-for-microsoft-365-experience-when-plain-copilot-isnt-enough.md
@@ -69,7 +69,7 @@ You need to be licensend for Copilot for Microsoft 365 to follow the steps below
 
 * Open Visual Studio Code and install Teams Toolkit.
   
-    ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/9107557b-15d6-470b-a0e7-0c698b648993.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/9107557b-15d6-470b-a0e7-0c698b648993.png)
     
 * Click on extensions in the menu on the left side,
   
@@ -80,41 +80,41 @@ You need to be licensend for Copilot for Microsoft 365 to follow the steps below
 
 * Click on Teams Toolkit and select “Create a New App”.
 
-* ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/3bd157e8-2555-45ac-b13a-4d1c874ecbd9.png)
+* ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/3bd157e8-2555-45ac-b13a-4d1c874ecbd9.png)
 
     Select “Copilot Agent”
 
-* ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/549de0b1-96d2-4cba-88e5-b584f35f1ecf.png)
+* ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/549de0b1-96d2-4cba-88e5-b584f35f1ecf.png)
 
     Select “Declarative Agent”
 
-* ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/02fb6a8c-e7f5-4585-b128-ea3b92b7f1f3.png)
+* ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/02fb6a8c-e7f5-4585-b128-ea3b92b7f1f3.png)
 
 * Select “No plugin”
 
-    ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/fd022f86-9771-4939-a4b9-8b3c80b6a829.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/fd022f86-9771-4939-a4b9-8b3c80b6a829.png)
 
 * Select a folder to store your agents “code”
 
-    ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/ff05d1ab-b123-4c21-b8b2-b6af2bff6f6d.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/ff05d1ab-b123-4c21-b8b2-b6af2bff6f6d.png)
 
 * Please give it a name
 
-    ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/b5075a1b-edbc-4ea6-aa95-38fb0d711709.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/b5075a1b-edbc-4ea6-aa95-38fb0d711709.png)
 
 * The extension will create your started code
 
-    ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/84edbbfe-35fe-4132-b08c-1d263d9fdb27.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/84edbbfe-35fe-4132-b08c-1d263d9fdb27.png)
 
     Click on the Teams Toolkit icon on the left side
 
     * select provision and
 
-        ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/e30b4c23-c5cb-45fc-84c8-2569a16ea8e9.png)
+        ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/e30b4c23-c5cb-45fc-84c8-2569a16ea8e9.png)
 
     * give it a try on [www.microsoft365.com/chat](https://www.microsoft365.com/chat)
 
-        ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/83b65200-3576-4b55-ba71-9fbb50115de8.png)
+        ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/83b65200-3576-4b55-ba71-9fbb50115de8.png)
 
         Click on the name of your just-created declarative Agent
 
@@ -133,7 +133,7 @@ to help customers understand the products better and resolve
 their queries efficiently.
 ```
 
-![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/5cfa199f-eaa7-4190-b793-25df64ac2ee9.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/5cfa199f-eaa7-4190-b793-25df64ac2ee9.png)
 
 * don’t forget to save
   
@@ -167,7 +167,7 @@ their queries efficiently.
     
     * Press provision again and see the result in the copilot chat window
       
-        ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/b18a0e18-b8e6-4454-94fa-3f8ae3ba1185.png)
+        ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/b18a0e18-b8e6-4454-94fa-3f8ae3ba1185.png)
         
         **Add Content from the web**
         
@@ -203,9 +203,9 @@ their queries efficiently.
         
         * Hit provision and start testing it again
           
-            ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/4ca804c1-90a8-4757-a314-a2ec026d962f.png)
+            ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/4ca804c1-90a8-4757-a314-a2ec026d962f.png)
             
-            ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/fc34c9c0-3a19-427a-9758-ca5c57011232.png)
+            ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/fc34c9c0-3a19-427a-9758-ca5c57011232.png)
             
     
     **Add OneDrive and Sharepoint Content**
@@ -277,7 +277,7 @@ their queries efficiently.
 }
 ```
 
-![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/50d6f372-f0d0-4035-99e5-f4994b542bc0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/50d6f372-f0d0-4035-99e5-f4994b542bc0.png)
 
 **Additional Resources**  
 please look at the [declarative Agent schema for Microsoft 365 Copilot](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/declarative-agent-manifest) for further details.
@@ -286,40 +286,40 @@ please look at the [declarative Agent schema for Microsoft 365 Copilot](https://
 
 * Click on “Create Agents” within your Copilot Chat
   
-* ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/d008e49d-a3c5-429f-883b-047ac3369bcb.png)
+* ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/d008e49d-a3c5-429f-883b-047ac3369bcb.png)
   
     Select “configure” on the top” and start to configure your declarative agents.
     
 * First, enter “Name”, “Description” and “Instructions”  
     We did this similar above in the declarativeAgent.json and instuction.txt file
     
-    ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/6ac8da10-22d1-4a89-8fb5-3e81f8bdbe32.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/6ac8da10-22d1-4a89-8fb5-3e81f8bdbe32.png)
     
-    ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/fb0bda42-e51f-4647-9391-f7536aebe8ab.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/fb0bda42-e51f-4647-9391-f7536aebe8ab.png)
     
     * Add your knowledge sources (SharePoint site and web search) - same as above with the teams toolkit
       
     
-    ![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/c160ce79-4d02-4400-9e77-aa4230d0832d.png)
+    ![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/c160ce79-4d02-4400-9e77-aa4230d0832d.png)
     
     * configure your conversation starter prompts with the same elements we used above within the declarativeAgent.json
       
 
-![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/b106876e-d947-4342-a435-f9a474135444.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/b106876e-d947-4342-a435-f9a474135444.png)
 
 - Hit “Create”
 
 
-![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/1ebcff35-73f7-4f3e-a0f9-707913f01944.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/1ebcff35-73f7-4f3e-a0f9-707913f01944.png)
 
-![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/a3d974f3-668a-4b76-b5be-66b0e45a244a.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/a3d974f3-668a-4b76-b5be-66b0e45a244a.png)
 
 * and give it a try
   
 
-![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/1aa138a1-100e-4f50-b226-2f8ba86bea3c.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/1aa138a1-100e-4f50-b226-2f8ba86bea3c.png)
 
-![]({{site.baseurl}}/images/cm2rmr6yz000109lc6els41rc.md/29aa7f12-2c5c-4a73-96a0-2c3157d04bdd.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm2rmr6yz000109lc6els41rc.md/29aa7f12-2c5c-4a73-96a0-2c3157d04bdd.png)
 
 ## Conclusion
 

--- a/holgerimbery/_posts/2024-11-03-revolutionizing-teamwork-unleashing-the-power-of-copilot-pages-for-seamless-document-collaboration-with-links-for-it-admins.md
+++ b/holgerimbery/_posts/2024-11-03-revolutionizing-teamwork-unleashing-the-power-of-copilot-pages-for-seamless-document-collaboration-with-links-for-it-admins.md
@@ -37,44 +37,44 @@ Here are some of its standout features:
 
 Open your copilot chat [https://www.microsoft365.com/chat](https://www.microsoft365.com/chat), ask a question, and integrate some documents.
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/76b86106-f72b-4e51-94be-8af2d40b8ced.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/76b86106-f72b-4e51-94be-8af2d40b8ced.png)
 
 * Refine your prompt and give it a try.
     
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/d2b882bf-c20e-456a-8c22-374cb9225ce0.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/d2b882bf-c20e-456a-8c22-374cb9225ce0.png)
 
 * See the result Copilot created for you.
     
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/493c26c8-4e62-4870-b982-86fc258cb49d.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/493c26c8-4e62-4870-b982-86fc258cb49d.png)
 
 * Scroll to the bottom and click on "Edit in Pages."
     
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/4d4f0f94-7065-4da8-a1bc-31bb04ffbb1b.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/4d4f0f94-7065-4da8-a1bc-31bb04ffbb1b.png)
 
 * A new canvas will open side by side, and you will see your Copilot page and a chat window.
     
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/b9d00580-e5b2-4f33-a9eb-be5ec2d2ecd4.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/b9d00580-e5b2-4f33-a9eb-be5ec2d2ecd4.png)
 
 * Select the shared element at the top right and share the page with a teammate.
     
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/236874e9-134a-431e-83a3-2d69874f725e.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/236874e9-134a-431e-83a3-2d69874f725e.png)
 
 * Your teammate will be able to edit the Copilot Pages and can also use Copilot (when licensed) as an assistant.
     
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/02e2b126-8acf-4722-b528-1702e731ae6f.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/02e2b126-8acf-4722-b528-1702e731ae6f.png)
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/32fce5b2-1db6-43b4-936c-f9606596a5ed.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/32fce5b2-1db6-43b4-936c-f9606596a5ed.png)
 
 * You will see the highlighted additions and can use the collaborative work result in any way.
     
 
-![]({{site.baseurl}}/images/cm31fkzxo000209mj2900huyy.md/6a9b644e-37d8-4f8e-964c-87cceebefba8.png)
+![](https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/cm31fkzxo000209mj2900huyy.md/6a9b644e-37d8-4f8e-964c-87cceebefba8.png)
 
 ## What is behind it?
 


### PR DESCRIPTION
## Summary
- rewrite inline markdown image links in posts from {{site.baseurl}}/images/... to raw GitHub URLs
- use base https://raw.githubusercontent.com/holgerimbery/holgerimbery.blog/main/holgerimbery/images/...
- keep frontmatter fields unchanged in this PR

## Scope
- 68 post files
- 562 inline image links rewritten