### PR TITLE
Replace archived notice text in archived posts

### DIFF
--- a/holgerimbery/_posts/2022-11-19-build-your-first-voice-bot-with-microsoft-power-virtual-agent-3e71f8531c3a.md
+++ b/holgerimbery/_posts/2022-11-19-build-your-first-voice-bot-with-microsoft-power-virtual-agent-3e71f8531c3a.md
@@ -12,7 +12,8 @@ featured: false
 toc: true
 
 ---
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Build your first (voice-)bot with Microsoft Power Virtual Agent
 

--- a/holgerimbery/_posts/2022-11-26-power-virtual-agents-application-lifecycle-management-38bf9882e2d6.md
+++ b/holgerimbery/_posts/2022-11-26-power-virtual-agents-application-lifecycle-management-38bf9882e2d6.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Power Virtual Agents Application Lifecycle Management
 

--- a/holgerimbery/_posts/2022-12-03-extend-power-virtual-agent-with-azure-cognitive-services-eab95018b7f6.md
+++ b/holgerimbery/_posts/2022-12-03-extend-power-virtual-agent-with-azure-cognitive-services-eab95018b7f6.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Extend Power Virtual Agent with Azure Cognitive Services
 

--- a/holgerimbery/_posts/2022-12-10-give-your-bots-a-voice.md
+++ b/holgerimbery/_posts/2022-12-10-give-your-bots-a-voice.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Give your Bots a voice
 

--- a/holgerimbery/_posts/2022-12-17-use-crm-data-in-your-power-virtual-agent-voice-bot.md
+++ b/holgerimbery/_posts/2022-12-17-use-crm-data-in-your-power-virtual-agent-voice-bot.md
@@ -12,7 +12,8 @@ featured: false
 toc: true
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2022-12-24-power-virtual-agents-developer-environment-a-low-code-platform-for-conversational-assistants.md
+++ b/holgerimbery/_posts/2022-12-24-power-virtual-agents-developer-environment-a-low-code-platform-for-conversational-assistants.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 
 # Power Virtual Agents - a low-code platform for conversational assistants

--- a/holgerimbery/_posts/2022-12-31-dynamics-365-customer-service-with-power-virtual-agents-part-1-automation-with-text-chat.md
+++ b/holgerimbery/_posts/2022-12-31-dynamics-365-customer-service-with-power-virtual-agents-part-1-automation-with-text-chat.md
@@ -14,7 +14,8 @@ toc: true
 ---
 
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Dynamics 365 Customer Service with Power Virtual Agents - Part 1 (automation with text chat)
 

--- a/holgerimbery/_posts/2023-01-07-dynamics-365-customer-service-with-power-virtual-agents-part-2-automation-with-voicevoice-bots.md
+++ b/holgerimbery/_posts/2023-01-07-dynamics-365-customer-service-with-power-virtual-agents-part-2-automation-with-voicevoice-bots.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 
 # Dynamics 365 Customer Service with Power Virtual Agents - Part 2 (automation with voice/voice bots)

--- a/holgerimbery/_posts/2023-01-14-the-chitchat-of-the-other-kind-chatgpt-in-power-virtual-agents.md
+++ b/holgerimbery/_posts/2023-01-14-the-chitchat-of-the-other-kind-chatgpt-in-power-virtual-agents.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # The Chitchat of the other kind - ChatGPT in Power Virtual Agents
 

--- a/holgerimbery/_posts/2023-01-21-power-virtual-agents-extensions-for-dynamics-365-workaround-on-installation-hiccups.md
+++ b/holgerimbery/_posts/2023-01-21-power-virtual-agents-extensions-for-dynamics-365-workaround-on-installation-hiccups.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Power Virtual Agents extensions for Dynamics 365 (workaround on installation hiccups)
 

--- a/holgerimbery/_posts/2023-01-28-multilingual-ivr-replacement-for-dynamics-365-customer-service-voice-bot.md
+++ b/holgerimbery/_posts/2023-01-28-multilingual-ivr-replacement-for-dynamics-365-customer-service-voice-bot.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Multilingual IVR Replacement for Dynamics 365 Customer Service (Voice Bot)
 

--- a/holgerimbery/_posts/2023-02-04-dynamics-365-customer-service-voice-channel.md
+++ b/holgerimbery/_posts/2023-02-04-dynamics-365-customer-service-voice-channel.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Dynamics 365 Customer Service Voice Channel
 

--- a/holgerimbery/_posts/2023-02-11-dynamics-365-customer-service-escalating-to-a-teams-user.md
+++ b/holgerimbery/_posts/2023-02-11-dynamics-365-customer-service-escalating-to-a-teams-user.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Dynamics 365 Customer Service - escalating to a Teams User
 

--- a/holgerimbery/_posts/2023-02-18-personalized-customer-experience-with-voice-bots-and-dynamics-365-customer-service.md
+++ b/holgerimbery/_posts/2023-02-18-personalized-customer-experience-with-voice-bots-and-dynamics-365-customer-service.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # personalized customer experience with voice bots and Dynamics 365 Customer Service
 

--- a/holgerimbery/_posts/2023-02-25-dynamics-365-customer-service-configure-call-recording-and-transcription-for-voice-bots-and-agent-dialogues.md
+++ b/holgerimbery/_posts/2023-02-25-dynamics-365-customer-service-configure-call-recording-and-transcription-for-voice-bots-and-agent-dialogues.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 # Dynamics 365 customer service: configure call recording and transcription for voice bots and agent dialogues
 

--- a/holgerimbery/_posts/2023-03-04-dynamics-365-customer-service-realtime-translation-to-break-barriers-in-text-chats.md
+++ b/holgerimbery/_posts/2023-03-04-dynamics-365-customer-service-realtime-translation-to-break-barriers-in-text-chats.md
@@ -14,7 +14,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Prerequisites
 

--- a/holgerimbery/_posts/2023-03-11-power-virtual-agents-use-openai-gpt-35-as-a-helper-for-trigger-phrases-and-custom-entities.md
+++ b/holgerimbery/_posts/2023-03-11-power-virtual-agents-use-openai-gpt-35-as-a-helper-for-trigger-phrases-and-custom-entities.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-03-18-dynamics-365-customer-service-always-an-answer-to-every-question.md
+++ b/holgerimbery/_posts/2023-03-18-dynamics-365-customer-service-always-an-answer-to-every-question.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-03-18-dynamics-365-customer-service-always-an-answer-to-every-question
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-03-25-power-virtual-agents-gpt-based-conversation-booster-preview.md
+++ b/holgerimbery/_posts/2023-03-25-power-virtual-agents-gpt-based-conversation-booster-preview.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-04-01-power-virtual-agents-create-and-edit-with-copilot-preview.md
+++ b/holgerimbery/_posts/2023-04-01-power-virtual-agents-create-and-edit-with-copilot-preview.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-04-08-azure-openai-services-getting-started.md
+++ b/holgerimbery/_posts/2023-04-08-azure-openai-services-getting-started.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 This is a first article of a series on Azure OpenAI Services. This article describes how to start and brings you directly to [Azure OpenAI Service Studio](https://oai.azure.com/).
 

--- a/holgerimbery/_posts/2023-04-15-creating-powerful-bots-with-power-virtual-agents-natural-language-understanding-and-custom-entities.md
+++ b/holgerimbery/_posts/2023-04-15-creating-powerful-bots-with-power-virtual-agents-natural-language-understanding-and-custom-entities.md
@@ -14,7 +14,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Power Virtual Agents is a virtual digital assistant SaaS Solution that uses Natural Language Understanding (NLU) to comprehend user intentions. NLU enables the bot to detect trigger phrases and identify entities within a user interaction, from phone numbers to zip codes and even names. Power Virtual Agents offers pre-constructed entities for commonly used data, such as ages, colors, numbers, and names, and allows for creating custom entities using closed list entities or regular expression entities. In addition, slot filling, a natural language understanding concept that saves an extracted entity to an object, which helps the bot provide more personalized and accurate responses based on the user's specific needs, can be used.
 

--- a/holgerimbery/_posts/2023-04-22-azure-openai-services-text-creation-and-modification.md
+++ b/holgerimbery/_posts/2023-04-22-azure-openai-services-text-creation-and-modification.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Learn how to generate or manipulate text using Azure OpenAI service. This powerful tool provides various models with an easy-to-use and efficient text-in, text-out interface. The model can accurately **cre**ate a completion that reflects the context or pattern provided by inputting a text prompt. Explore the capabilities of completions with [Azure OpenAI Studio's Playground](https://oai.azure.com/), and discover how to control the variance by adjusting the temperature setting. Follow the guidelines to create effective prompts for content creation, classification, and conversation tasks.
 

--- a/holgerimbery/_posts/2023-04-29-power-virtual-agents-licensing.md
+++ b/holgerimbery/_posts/2023-04-29-power-virtual-agents-licensing.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-04-29-power-virtual-agents-licensing
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-05-06-bot-framework-composer-and-power-virtual-agents-why-its-time-to-make-the-switch.md
+++ b/holgerimbery/_posts/2023-05-06-bot-framework-composer-and-power-virtual-agents-why-its-time-to-make-the-switch.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-05-06-bot-framework-composer-and-power-virtual-agents-why-its-time-to-make-the-switch
 
 ---
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 
  Important!  

--- a/holgerimbery/_posts/2023-05-13-power-virtual-agents-find-online-content-based-topic-suggestions.md
+++ b/holgerimbery/_posts/2023-05-13-power-virtual-agents-find-online-content-based-topic-suggestions.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 
 Power Virtual Agents is a powerful tool that allows users to populate their chatbots with existing web pages or files. With AI-assisted authoring technology, this feature recognizes a webpage's or online file's structure and content and segregates relevant content blocks related to a support issue or question. This article explains how to use the Suggested Topics feature in three easy steps and how to extract content from web pages or online files. Additionally, it discusses single-turn and multi-turn topic suggestions and how to add them to an existing bot.

--- a/holgerimbery/_posts/2023-05-20-power-virtual-agents-and-powerfx-a-sneak-peek.md
+++ b/holgerimbery/_posts/2023-05-20-power-virtual-agents-and-powerfx-a-sneak-peek.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Power Virtual Agents and PowerFX are two powerful tools that can create complex logic for bots to manipulate data. With these tools, you can create bots with more complex logic without the need for extensive development. PowerFx is a low-code language that allows users to set the value of a variable, parse strings, and use expressions in conditions. In this article, we take a sneak peek at the capabilities and applications of Power Virtual Agents and PowerFX, including how to use variables and literal values in formulas and how to use PowerFX to set a variable as a condition.
 

--- a/holgerimbery/_posts/2023-05-27-business-process-automation-for-sustainability-why-it-matters.md
+++ b/holgerimbery/_posts/2023-05-27-business-process-automation-for-sustainability-why-it-matters.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 In my previous articles, I focused on the how, and here I will switch the perspective and dig deeper into the why.
 

--- a/holgerimbery/_posts/2023-06-03-transform-your-ai-assistants-with-the-ability-to-generate-answers-perform-actions-and-additional-features-using-microsoft-power-virtual-agents.md
+++ b/holgerimbery/_posts/2023-06-03-transform-your-ai-assistants-with-the-ability-to-generate-answers-perform-actions-and-additional-features-using-microsoft-power-virtual-agents.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Bots are handy tools in today's fast-paced digital world, serving as virtual assistants to help users accomplish various tasks. These bots primarily perform two essential functions: answering user queries or completing actions by calling backend APIs. In the past, both experiences had to be painstakingly crafted using hand-built dialogues. Bot builders would have to anticipate every possible question or action a user might request and then construct specific conversations to address each.
 

--- a/holgerimbery/_posts/2023-06-10-creating-multilingual-chatbots-with-power-virtual-agents-3-workarounds-to-get-started.md
+++ b/holgerimbery/_posts/2023-06-10-creating-multilingual-chatbots-with-power-virtual-agents-3-workarounds-to-get-started.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-06-17-dynamics-365-customer-service-design-your-own-live-chat-experience.md
+++ b/holgerimbery/_posts/2023-06-17-dynamics-365-customer-service-design-your-own-live-chat-experience.md
@@ -12,7 +12,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-06-24-dynamics-365-customer-service-assessing-customer-experience-with-surveys.md
+++ b/holgerimbery/_posts/2023-06-24-dynamics-365-customer-service-assessing-customer-experience-with-surveys.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-06-24-dynamics-365-customer-service-assessing-customer-experience-with-surveys
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-07-01-dynamics-365-customer-service-effortlessly-detect-clients-in-conversations.md
+++ b/holgerimbery/_posts/2023-07-01-dynamics-365-customer-service-effortlessly-detect-clients-in-conversations.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-07-01-dynamics-365-customer-service-effortlessly-detect-clients-in-conversations
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 You can better assist customers by automatically identifying them and viewing their account and case details on the Active Conversation page. One way to achieve this is by setting up pre-conversation questions in the appropriate chat widgets. See here my blog article "[Assessing Customer Experience with Surveys](https://the.cognitiveservices.ninja/dynamics-365-customer-service-assessing-customer-experience-with-surveys)".
 

--- a/holgerimbery/_posts/2023-07-08-power-virtual-agent-in-a-day-a-curated-link-list.md
+++ b/holgerimbery/_posts/2023-07-08-power-virtual-agent-in-a-day-a-curated-link-list.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Attending a "Power Virtual Agent in a Day" (PVAinaDay) workshop is highly recommended when beginning with Power Virtual Agents. After conducting numerous workshops alongside colleagues and utilizing our script to engage participants, we adopted Microsoft's new "Power Virtual Agents in a Day" curriculum.
 

--- a/holgerimbery/_posts/2023-07-15-enhancing-customer-support-with-dynamics-365-copilot.md
+++ b/holgerimbery/_posts/2023-07-15-enhancing-customer-support-with-dynamics-365-copilot.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Copilot for Dynamics 365 Customer Service is an AI-powered tool designed to enhance the agent experience. By providing real-time, AI-driven assistance, agents can swiftly resolve issues, effectively manage cases, and automate routine tasks. This enables them to concentrate on delivering exceptional customer service and fostering genuine human-to-human interactions.
 

--- a/holgerimbery/_posts/2023-07-22-enhancing-customer-support-with-power-virtual-agent-copilot.md
+++ b/holgerimbery/_posts/2023-07-22-enhancing-customer-support-with-power-virtual-agent-copilot.md
@@ -14,7 +14,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 By harnessing the power of AI large language models, Power Virtual Agents revolutionizes chatbot development, enhancing their utility and significantly minimizing manual authoring and configuration requirements.
 

--- a/holgerimbery/_posts/2023-07-29-generative-answers-with-power-virtual-agents.md
+++ b/holgerimbery/_posts/2023-07-29-generative-answers-with-power-virtual-agents.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-07-29-generative-answers-with-power-virtual-agents
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Generative answers within Power Virtual Agents offer a convenient way for your bot to retrieve and display information from various sources, both internal and external. Unlike authored topics, generative answers do not require pre-determined subjects to be created beforehand. They can serve as your chatbot's main information source or be a fallback option when existing topics fail to address user inquiries. This feature streamlines the bot creation process by enabling you to build and launch a functional chatbot quickly without spending time manually authoring multiple topics that may not adequately address customer queries.
 

--- a/holgerimbery/_posts/2023-08-12-elevate-your-dynamics-365-customer-service-with-the-voice-channel-a-simple-guide.md
+++ b/holgerimbery/_posts/2023-08-12-elevate-your-dynamics-365-customer-service-with-the-voice-channel-a-simple-guide.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-08-12-elevate-your-dynamics-365-customer-service-with-the-voice-channel-a-simple-guide
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 In Dynamics 365 Customer Service, representatives can use the voice channel to communicate with customers over the phone and resolve issues. Although chat, SMS messages, and social media have become popular channels for customers to seek support from organizations, phone calls remain a critical communication option. In Omnichannel for Customer Service, agents can receive and make public switched telephone network (PSTN) calls using a native calling experience in Dynamics 365. The voice channel also offers real-time AI-powered features such as live call transcription, sentiment analysis, and AI-based suggestions that help enhance agent productivity. Moreover, Omnichannel for Customer Service provides a broad range of analytics and insights, including AI-driven topic clustering and call insights.
 

--- a/holgerimbery/_posts/2023-08-19-customer-service-automation-the-perfect-duo-of-dynamics-365-customer-service-power-virtual-agent.md
+++ b/holgerimbery/_posts/2023-08-19-customer-service-automation-the-perfect-duo-of-dynamics-365-customer-service-power-virtual-agent.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-08-27-azure-openai-services-working-with-your-own-data-without-compromising-your-intellectual-property.md
+++ b/holgerimbery/_posts/2023-08-27-azure-openai-services-working-with-your-own-data-without-compromising-your-intellectual-property.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-08-27-azure-openai-services-working-with-your-own-data-without-compromising-your-intellectual-property
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation  
 

--- a/holgerimbery/_posts/2023-09-03-azure-openai-services-as-a-copilot-in-visual-studio-code.md
+++ b/holgerimbery/_posts/2023-09-03-azure-openai-services-as-a-copilot-in-visual-studio-code.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## **Motivation**
 

--- a/holgerimbery/_posts/2023-09-10-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-1-a-simple-web-chat-experience-targeting-chatgpt-through-aoai.md
+++ b/holgerimbery/_posts/2023-09-10-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-1-a-simple-web-chat-experience-targeting-chatgpt-through-aoai.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-09-16-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-2-incorporating-your-own-data-to-create-unique-experiences.md
+++ b/holgerimbery/_posts/2023-09-16-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-2-incorporating-your-own-data-to-create-unique-experiences.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 
  second part of a series  

--- a/holgerimbery/_posts/2023-09-22-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-3-activate-chat-history-for-adding-a-more-convenient-way-to-work.md
+++ b/holgerimbery/_posts/2023-09-22-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-3-activate-chat-history-for-adding-a-more-convenient-way-to-work.md
@@ -12,7 +12,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Third part of a series  
 building the foundation - [part 1](https://the.cognitiveservices.ninja/create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-2-incorporating-your-own-data-to-create-unique-experiences) &  

--- a/holgerimbery/_posts/2023-09-30-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-4-adding-additional-channels-and-take-action-on-your-data.md
+++ b/holgerimbery/_posts/2023-09-30-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-4-adding-additional-channels-and-take-action-on-your-data.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
  ***Third part of a series  
  building the foundation -*** [***part 1***](https://the.cognitiveservices.ninja/create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-2-incorporating-your-own-data-to-create-unique-experiences) ***&  

--- a/holgerimbery/_posts/2023-10-07-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-5-refine-and-enhance-knowledge-on-your-own-data.md
+++ b/holgerimbery/_posts/2023-10-07-create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-5-refine-and-enhance-knowledge-on-your-own-data.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
  ***5\. part of a series  
  building the foundation -*** [***part 1***](https://the.cognitiveservices.ninja/create-your-owngpt-in-a-protected-way-and-advance-its-potential-part-2-incorporating-your-own-data-to-create-unique-experiences) ***&  

--- a/holgerimbery/_posts/2023-10-14-revolutionizing-bot-building-unleash-the-power-of-generative-actions-in-power-virtual-agents.md
+++ b/holgerimbery/_posts/2023-10-14-revolutionizing-bot-building-unleash-the-power-of-generative-actions-in-power-virtual-agents.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
  Note:  
  This article showcases a preview feature. Preview features are not intended for production use and may possess limited functionality. These features are made available prior to an official release, allowing customers to gain early access and offer feedback.

--- a/holgerimbery/_posts/2023-10-21-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-1-the-basics.md
+++ b/holgerimbery/_posts/2023-10-21-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-1-the-basics.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-10-28-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-2-environment-setup.md
+++ b/holgerimbery/_posts/2023-10-28-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-2-environment-setup.md
@@ -13,7 +13,8 @@ toc: true
  
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 This is the second part of a series of articles, [part 1 (basics and background)](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-1-the-basics) was published before.
 

--- a/holgerimbery/_posts/2023-11-04-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-3-working-with-solutions.md
+++ b/holgerimbery/_posts/2023-11-04-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-3-working-with-solutions.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 This is the third part of a series of articles, [part 1 (basics and background](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-1-the-basics) & [part 2 (preparing your environments)](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-2-environment-setup) were published before.
 

--- a/holgerimbery/_posts/2023-11-11-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-4-working-with-pipelines.md
+++ b/holgerimbery/_posts/2023-11-11-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-4-working-with-pipelines.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
  This is the fourth part of a series of articles, [part 1 (basics and background](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-1-the-basics) & [part 2 (preparing your environments](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-2-environment-setup)) & [part 3 (working with solutions)](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-3-working-with-solutions) were published before.
 

--- a/holgerimbery/_posts/2023-11-18-multilingual-magic-power-virtual-agents-copilots-for-global-engagement-preview.md
+++ b/holgerimbery/_posts/2023-11-18-multilingual-magic-power-virtual-agents-copilots-for-global-engagement-preview.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Multilingual bots are chatbots capable of communicating with customers in various languages while maintaining all content within a single bot. Often, they can automatically detect the preferred language and respond accordingly, offering customers a more personalized and engaging experience. This long-awaited feature is now on the horizon for Power Virtual Agents / Copilot Studio as a preview feature. There is no need to develop a separate bot for each required language.
 

--- a/holgerimbery/_posts/2023-11-25-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-5-approval-with-pipeline.md
+++ b/holgerimbery/_posts/2023-11-25-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-5-approval-with-pipeline.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
   
  ***This is the fifth part of a series of articles,*** [***part 1 (basics and background***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-1-the-basics) ***&*** [***part 2 (preparing your environments***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-2-environment-setup)***) &*** [***part 3 (working with solutions***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-3-working-with-solutions)***) &*** [***part 4 (working with pipelines)***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-4-working-with-pipelines) ***were published before.***
 

--- a/holgerimbery/_posts/2023-12-02-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-6-digging-deeper.md
+++ b/holgerimbery/_posts/2023-12-02-mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-6-digging-deeper.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
  ***This is the sixth part of a series of articles,*** [***part 1 (basics and background***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-1-the-basics) ***&*** [***part 2 (preparing your environments***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-2-environment-setup)***) &*** [***part 3 (working with solutions***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-3-working-with-solutions)***) &*** [***part 4 (working with pipelines***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-4-working-with-pipelines) ***&*** [***part 5 (approvals with pipelines)***](https://the.cognitiveservices.ninja/mastering-alm-application-lifecycle-management-for-microsoft-power-platform-a-comprehensive-guide-part-5-approval-with-pipeline) ***were published before.***
 

--- a/holgerimbery/_posts/2023-12-09-sharepoint-integration-add-your-custom-microsoft-copilot-studio-copilot-with-sso-support.md
+++ b/holgerimbery/_posts/2023-12-09-sharepoint-integration-add-your-custom-microsoft-copilot-studio-copilot-with-sso-support.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 Integrating a Microsoft CoPilot Studio Copilot into a Microsoft SharePoint site can significantly enhance user experience and productivity. This assistant can provide real-time assistance to users, guiding them through the site, answering their questions, and helping them complete tasks more efficiently.
 

--- a/holgerimbery/_posts/2023-12-16-dynamics-365-customer-service-verify-users-with-a-single-use-password-in-text-chat.md
+++ b/holgerimbery/_posts/2023-12-16-dynamics-365-customer-service-verify-users-with-a-single-use-password-in-text-chat.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Motivation
 

--- a/holgerimbery/_posts/2023-12-23-leveraging-dynamics-365-customer-service-for-a-superior-digital-contact-center-experience.md
+++ b/holgerimbery/_posts/2023-12-23-leveraging-dynamics-365-customer-service-for-a-superior-digital-contact-center-experience.md
@@ -13,7 +13,8 @@ toc: true
 
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 ## Introduction
 

--- a/holgerimbery/_posts/2023-12-30-exploring-the-potential-of-retrieval-augmented-generation-using-azure-open-ai-solutions-and-build-your-owngpt.md
+++ b/holgerimbery/_posts/2023-12-30-exploring-the-potential-of-retrieval-augmented-generation-using-azure-open-ai-solutions-and-build-your-owngpt.md
@@ -12,7 +12,8 @@ toc: true
 # 2023-12-30-exploring-the-potential-of-retrieval-augmented-generation-using-azure-open-ai-solutions-and-build-your-owngpt
 ---
 
-*Archived post - content may be outdate*
+{: .caution }
+**Archived post for reference**: This article remains available because it may still provide useful context or historical insight. However, technologies, features, and recommendations may have changed since it was published.
 
 In the realm of artificial intelligence (AI), Retrieval-Augmented Generation (RAG) is a groundbreaking approach that enhances the output of large language models (LLMs). It achieves this by referencing a reliable external knowledge base, separate from its original training data sources, before generating a response.
 


### PR DESCRIPTION
## Summary
- replace legacy archived warning line in posts
- use a standardized caution block with updated wording
- apply consistently across all matching archived posts