### PR TITLE
ci: add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,60 @@
+name: Deploy Jekyll to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Grant the GITHUB_TOKEN permissions needed by the deploy job
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment; cancel in-progress runs
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: holgerimbery
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: holgerimbery
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: holgerimbery/_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the Jekyll site from `holgerimbery/` and deploys it to GitHub Pages automatically on every push to `main`.

## What was added

- `.github/workflows/deploy-gh-pages.yml` — two-job pipeline:
  - **build**: checks out the repo, sets up Ruby 3.3, runs `bundle exec jekyll build`, uploads the `_site` artifact
  - **deploy**: deploys the artifact to GitHub Pages

## Required setup on GitHub.com

Before the workflow will work, enable Pages in the repo settings:

1. Go to **Settings → Pages**
2. Under **Build and deployment → Source**, choose **GitHub Actions**
3. Click **Save**

> **Optional:** Add a custom domain (`holgerimbery.blog`) on the same page if you want it pointed here instead of Azure Static Web Apps.